### PR TITLE
docs(ports): add Javadoc to 5 hexagonal ports

### DIFF
--- a/pii-reporting-api/src/main/java/pro/softcom/aisentinel/application/confluence/port/in/ConfluenceSpacePort.java
+++ b/pii-reporting-api/src/main/java/pro/softcom/aisentinel/application/confluence/port/in/ConfluenceSpacePort.java
@@ -7,12 +7,30 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * Input port exposing read-only Confluence space and page operations to the application layer.
+ *
+ * <p>All operations are asynchronous ({@link CompletableFuture}) to support non-blocking scan
+ * workflows. Implementations are expected to delegate to a Confluence REST client.
+ */
 public interface ConfluenceSpacePort {
+
+  /** Probes the configured Confluence instance for reachability and authentication. */
   CompletableFuture<Boolean> testConnection();
+
+  /** Fetches a single page by its identifier, empty when absent. */
   CompletableFuture<Optional<ConfluencePage>> getPage(String pageId);
+
+  /** Searches pages within a space matching the given free-text query. */
   CompletableFuture<List<ConfluencePage>> searchPages(String spaceKey, String query);
+
+  /** Fetches a single space by its key, empty when absent. */
   CompletableFuture<Optional<ConfluenceSpace>> getSpace(String spaceKey);
+
+  /** Lists all spaces the authenticated user can access. */
   CompletableFuture<List<ConfluenceSpace>> getAllSpaces();
+
+  /** Lists all pages within the given space. */
   CompletableFuture<List<ConfluencePage>> getAllPagesInSpace(String spaceKey);
 }
 

--- a/pii-reporting-api/src/main/java/pro/softcom/aisentinel/application/confluence/port/out/ConfluenceSpaceRepository.java
+++ b/pii-reporting-api/src/main/java/pro/softcom/aisentinel/application/confluence/port/out/ConfluenceSpaceRepository.java
@@ -5,11 +5,20 @@ import pro.softcom.aisentinel.domain.confluence.ConfluenceSpace;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * Output port for persisting and querying the local cache of Confluence spaces.
+ *
+ * <p>Implementations typically back a relational store used to avoid hitting the Confluence API
+ * for stable metadata (space keys, names, URLs).
+ */
 public interface ConfluenceSpaceRepository {
 
+    /** Returns all cached spaces in no guaranteed order. */
     List<ConfluenceSpace> findAll();
 
+    /** Fetches a cached space by its unique Confluence key, empty when absent. */
     Optional<ConfluenceSpace> findByKey(String key);
 
+    /** Persists the given spaces, replacing any existing entries with the same key. */
     void saveAll(List<ConfluenceSpace> spaces);
 }

--- a/pii-reporting-api/src/main/java/pro/softcom/aisentinel/application/pii/reporting/port/in/PauseScanPort.java
+++ b/pii-reporting-api/src/main/java/pro/softcom/aisentinel/application/pii/reporting/port/in/PauseScanPort.java
@@ -1,6 +1,17 @@
 package pro.softcom.aisentinel.application.pii.reporting.port.in;
 
+/**
+ * Input port for pausing a running scan identified by its {@code scanId}.
+ *
+ * <p>Pausing transitions checkpoints to a PAUSED status so the scan can be resumed later without
+ * losing progress. Calling this for an unknown or already-completed scan is a no-op.
+ */
 public interface PauseScanPort {
 
+    /**
+     * Requests the scan with the given identifier to pause at the next safe checkpoint.
+     *
+     * @param scanId unique identifier of the running scan
+     */
     void pauseScan(String scanId);
 }

--- a/pii-reporting-api/src/main/java/pro/softcom/aisentinel/application/pii/reporting/port/out/PublishEventPort.java
+++ b/pii-reporting-api/src/main/java/pro/softcom/aisentinel/application/pii/reporting/port/out/PublishEventPort.java
@@ -2,6 +2,14 @@ package pro.softcom.aisentinel.application.pii.reporting.port.out;
 
 import pro.softcom.aisentinel.domain.pii.scan.SpaceScanCompleted;
 
+/**
+ * Output port for publishing domain events emitted by the scan application layer.
+ *
+ * <p>Decouples the application layer from any concrete messaging/event infrastructure (internal
+ * bus, Spring events, Kafka, etc.).
+ */
 public interface PublishEventPort {
+
+    /** Publishes the terminal event signalling that a space scan has completed. */
     void publishCompleteEvent(SpaceScanCompleted spaceScanCompleted);
 }

--- a/pii-reporting-api/src/main/java/pro/softcom/aisentinel/application/pii/reporting/port/out/ScanTimeOutConfig.java
+++ b/pii-reporting-api/src/main/java/pro/softcom/aisentinel/application/pii/reporting/port/out/ScanTimeOutConfig.java
@@ -2,7 +2,14 @@ package pro.softcom.aisentinel.application.pii.reporting.port.out;
 
 import java.time.Duration;
 
+/**
+ * Output port exposing tunable timeouts used by the scan pipeline.
+ *
+ * <p>Abstracts the underlying configuration source (application properties, remote config, etc.)
+ * so the application layer remains framework-agnostic.
+ */
 public interface ScanTimeOutConfig {
 
+    /** Maximum duration allowed for a single PII detection call on a piece of content. */
     Duration getPiiDetection();
 }


### PR DESCRIPTION
## Summary
- Add Javadoc to 5 application-layer ports that previously had no documentation
- Javadoc describes the contract and intent, not the implementation

## Category
- [ ] Algorithmic optimization
- [ ] Missing tests
- [ ] Refactoring
- [x] Documentation
- [ ] SonarQube issue fix

## Files changed
- `ConfluenceSpacePort.java` — async input port for Confluence space/page read operations
- `ConfluenceSpaceRepository.java` — output port for the local cache of Confluence spaces
- `PauseScanPort.java` — input port to pause a running scan
- `PublishEventPort.java` — output port to publish domain events
- `ScanTimeOutConfig.java` — output port exposing tunable timeouts

## Verification
- [x] Tests pass for all modified modules (HexagonalArchitectureTest 13/13)
- [x] Build succeeds (mvn compile)
- [x] No functional change (documentation-only)
- [x] Max 5 files modified (exactly 5 files)
- [x] No protected files modified

## Details
Each port receives:
1. A class-level Javadoc explaining its role (input vs output port) and the layer boundary it enforces.
2. Per-method Javadoc describing the contract (inputs, return semantics, empty-case handling).

Javadoc style aligned with existing documented ports (e.g. `ScanReportingPort`, `RevealPiiSecretsPort`).

---
*Generated by Claude Code — autonomous continuous improvement*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive Javadoc documentation to internal API components covering Confluence integration, scan management, and event publishing workflows, improving developer reference materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->