### PR TITLE
docs(ports): add Javadoc to 3 scan and detection ports

### DIFF
--- a/pii-reporting-api/src/main/java/pro/softcom/aisentinel/application/pii/export/port/out/ReadScanEventsPort.java
+++ b/pii-reporting-api/src/main/java/pro/softcom/aisentinel/application/pii/export/port/out/ReadScanEventsPort.java
@@ -4,6 +4,20 @@ import pro.softcom.aisentinel.domain.pii.reporting.ConfluenceContentScanResult;
 
 import java.util.stream.Stream;
 
+/**
+ * Output port for replaying persisted scan events (e.g. during report export).
+ *
+ * <p>Returns a lazy {@link Stream} so consumers can process large scans without loading the full
+ * event history into memory. Callers are responsible for closing the stream.
+ */
 public interface ReadScanEventsPort {
+
+    /**
+     * Streams scan events for the given scan identifier and space key in persistence order.
+     *
+     * @param scanId   unique identifier of the scan
+     * @param spaceKey Confluence space key, used to filter events
+     * @return a lazy stream of scan results; must be closed by the caller
+     */
     Stream<ConfluenceContentScanResult> streamByScanIdAndSpaceKey(String scanId, String spaceKey);
 }

--- a/pii-reporting-api/src/main/java/pro/softcom/aisentinel/application/pii/reporting/port/in/StreamConfluenceScanPort.java
+++ b/pii-reporting-api/src/main/java/pro/softcom/aisentinel/application/pii/reporting/port/in/StreamConfluenceScanPort.java
@@ -6,10 +6,19 @@ import reactor.core.publisher.Flux;
 import java.util.List;
 
 /**
- * Use case orchestrating Confluence scans and PII detection.
+ * Input port orchestrating Confluence scans and PII detection as reactive streams.
+ *
+ * <p>Each operation returns a {@link Flux} that emits a {@link ConfluenceContentScanResult} per
+ * analyzed page/attachment, allowing downstream SSE delivery without buffering the full scan.
  */
 public interface StreamConfluenceScanPort {
+
+    /** Streams PII detection results for every page/attachment in the given space. */
     Flux<ConfluenceContentScanResult> streamSpace(String spaceKey);
+
+    /** Streams PII detection results across every accessible Confluence space. */
     Flux<ConfluenceContentScanResult> streamAllSpaces();
+
+    /** Streams PII detection results restricted to the given space keys. */
     Flux<ConfluenceContentScanResult> streamSelectedSpaces(List<String> spaceKeys);
 }

--- a/pii-reporting-api/src/main/java/pro/softcom/aisentinel/application/pii/scan/port/out/PiiDetectorClient.java
+++ b/pii-reporting-api/src/main/java/pro/softcom/aisentinel/application/pii/scan/port/out/PiiDetectorClient.java
@@ -2,13 +2,25 @@ package pro.softcom.aisentinel.application.pii.scan.port.out;
 
 import pro.softcom.aisentinel.domain.pii.scan.ContentPiiDetection;
 
+/**
+ * Output port for delegating PII detection on raw text content to an external detector.
+ *
+ * <p>Implementations typically wrap a gRPC or HTTP client to the PII detector service. The
+ * {@code analyzePageContent} overloads enrich detections with page/space metadata useful for
+ * downstream reporting, while the plain {@code analyzeContent} variants are suitable for
+ * stateless content scanning (e.g. attachments).
+ */
 public interface PiiDetectorClient {
 
+    /** Analyzes raw text content using the detector default confidence threshold. */
     ContentPiiDetection analyzeContent(String content) throws PiiDetectorException;
 
+    /** Analyzes raw text content, keeping only detections above the given confidence threshold. */
     ContentPiiDetection analyzeContent(String content, float threshold) throws PiiDetectorException;
 
+    /** Analyzes page content and tags detections with the source page/space metadata. */
     ContentPiiDetection analyzePageContent(String pageId, String pageTitle, String spaceKey, String content) throws PiiDetectorException;
 
+    /** Analyzes page content with a custom confidence threshold; detections are tagged with page metadata. */
     ContentPiiDetection analyzePageContent(String pageId, String pageTitle, String spaceKey, String content, float threshold) throws PiiDetectorException;
 }


### PR DESCRIPTION
## Summary
- Add Javadoc to 3 application-layer ports related to scanning and PII detection
- Focuses on contracts (what the interface guarantees) rather than implementation

## Category
- [ ] Algorithmic optimization
- [ ] Missing tests
- [ ] Refactoring
- [x] Documentation
- [ ] SonarQube issue fix

## Files changed
- `PiiDetectorClient.java` — output port wrapping the external PII detector service
- `ReadScanEventsPort.java` — output port for replaying persisted scan events (lazy Stream)
- `StreamConfluenceScanPort.java` — input port for reactive Confluence scan orchestration (Flux)

## Verification
- [x] Tests pass for all modified modules (HexagonalArchitectureTest 13/13)
- [x] Build succeeds (mvn compile)
- [x] No functional change (documentation-only)
- [x] Max 5 files modified (3 files)
- [x] No protected files modified

## Details
Each port receives:
1. A class-level Javadoc clarifying the port role (input vs output), what it wraps, and usage caveats (e.g. `ReadScanEventsPort` Stream must be closed by caller).
2. Per-method Javadoc describing parameters, return semantics, and overload differences.

Follows the style established in PR #74 (Javadoc for 5 other hexagonal ports).

---
*Generated by Claude Code — autonomous continuous improvement*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Javadoc for internal API interfaces to clarify functionality and usage patterns for scan event streaming, Confluence content processing, and PII detection operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->