### PR TITLE
perf(detector): true sweep-line overlap resolution + hoist Presidio import

### DIFF
--- a/pii-detector-service/pii_detector/domain/service/detection_merger.py
+++ b/pii-detector-service/pii_detector/domain/service/detection_merger.py
@@ -191,48 +191,61 @@ class DetectionMerger:
 
     def _resolve_overlaps_for_type(self, entities: List[PIIEntity]) -> List[PIIEntity]:
         """
-        Resolve overlaps for a single entity type using sweep-line algorithm.
-        
+        Resolve overlaps for a single entity type using a true sweep-line scan.
+
+        Algorithm (O(n log n) total — sort + linear scan):
+
+        1. Sort by ``(start ASC, -length DESC, -score DESC)``.
+        2. Keep only the entity that ends the latest among those started so far.
+
+        Why a single comparison against the last kept entity is sufficient:
+
+        - After sorting by ``start`` ascending, every entity processed has
+          ``start >= last_kept.start``. An "earlier" kept entity can only
+          conflict with the current one if it overlaps it, but if such an
+          earlier entity were "active" we would have used it as a comparison
+          point — instead the sort guarantees the most recently kept entity
+          covers the right-most accepted region.
+        - The ``-length`` tiebreaker means that for entities sharing a start,
+          the longest comes first. The ``current_contains_kept`` branch in
+          the previous implementation was therefore unreachable: a later
+          entity at the same start cannot be longer.
+
+        Result: behaviour is preserved (validated by existing
+        ``test_detection_merger.py`` cases) but the inner O(n) scan over
+        ``kept`` is replaced by an O(1) check, dropping the worst case from
+        O(n²) to O(n log n) — matching the docstring that has always claimed
+        sweep-line complexity.
+
         Args:
             entities: List of entities of the same type
-            
+
         Returns:
             List of non-overlapping entities with best spans kept
         """
         if len(entities) <= 1:
             return entities
-        
-        # Sort by start position, then by span length (longest first), then by score (highest first)
+
         sorted_entities = sorted(
             entities,
             key=lambda e: (e.start, -(e.end - e.start), -e.score)
         )
-        
+
         kept: List[PIIEntity] = []
         for current in sorted_entities:
-            should_keep = True
-            remove_indices = []
-            
-            for i, kept_entity in enumerate(kept):
-                overlap_type = self._check_overlap(kept_entity, current)
-                
-                if overlap_type == 'none':
-                    continue
-                elif overlap_type == 'current_contains_kept':
-                    # Current entity is larger and contains a kept entity - replace it
-                    remove_indices.append(i)
-                elif overlap_type in ('kept_contains_current', 'partial'):
-                    # Kept entity is larger or they partially overlap - skip current
-                    should_keep = False
-                    break
-            
-            # Remove kept entities that are contained in the current larger entity
-            for idx in reversed(remove_indices):
-                kept.pop(idx)
-            
-            if should_keep:
+            if not kept:
                 kept.append(current)
-        
+                continue
+
+            last = kept[-1]
+            # Sort guarantees `current.start >= last.start`. The two entities
+            # are disjoint iff the previous one ends before this one starts.
+            if current.start >= last.end:
+                kept.append(current)
+            # Otherwise the current entity is either contained in `last` (sort
+            # key forbids it from extending further right when starts tie) or
+            # partially overlaps; in both cases the earlier-kept entity wins.
+
         return kept
 
     def _check_overlap(self, e1: PIIEntity, e2: PIIEntity) -> str:

--- a/pii-detector-service/pii_detector/infrastructure/adapter/in/grpc/pii_service.py
+++ b/pii-detector-service/pii_detector/infrastructure/adapter/in/grpc/pii_service.py
@@ -76,6 +76,14 @@ except Exception:  # pragma: no cover - safe import guard
     create_composite_detector = None  # type: ignore
     should_use_composite_detector = None  # type: ignore
 
+# Presidio detector — imported at module scope so the per-request
+# _pass_fresh_configs_to_presidio path no longer pays import-machinery cost.
+# Same try/except pattern as the other optional detectors above.
+try:
+    from pii_detector.infrastructure.detector.presidio_detector import PresidioDetector
+except Exception:  # pragma: no cover - safe import guard
+    PresidioDetector = None  # type: ignore
+
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
@@ -779,11 +787,14 @@ class PIIDetectionServicer(pii_detection_pb2_grpc.PIIDetectionServiceServicer):
         if not pii_type_configs:
             logger.debug(f"[{request_id}] No fresh configs to pass to Presidio")
             return
-        
+
+        if PresidioDetector is None:
+            logger.debug(
+                f"[{request_id}] PresidioDetector module unavailable; skipping fresh configs hand-off"
+            )
+            return
+
         try:
-            # Import here to avoid circular dependencies
-            from pii_detector.infrastructure.detector.presidio_detector import PresidioDetector
-            
             # Case 1: Direct PresidioDetector
             if isinstance(self.detector, PresidioDetector):
                 logger.info(


### PR DESCRIPTION
## Summary
Two correlated Python optimisations:

1. **`DetectionMerger._resolve_overlaps_for_type`** — replace the O(n²) double loop with a real O(n log n) sweep-line scan. The previous code already sorted entities, but then performed a linear scan over the growing `kept` list for every entity.
2. **`PIIDetectionServicer._pass_fresh_configs_to_presidio`** — hoist the in-method `from ... import PresidioDetector` to module scope, matching the pattern already used by the other optional detector imports in the same file.

## Category
- [x] Algorithmic optimization
- [ ] Missing tests
- [ ] Refactoring
- [ ] Documentation
- [ ] SonarQube issue fix

## Files changed
- `pii-detector-service/pii_detector/domain/service/detection_merger.py` — sweep-line refactor
- `pii-detector-service/pii_detector/infrastructure/adapter/in/grpc/pii_service.py` — module-level Presidio import + early-return guard

## Verification
- [x] Python syntax OK (`python -m py_compile`)
- [x] Behaviour preserved — covered by existing `test_detection_merger.py` cases:
  - `test_should_keep_longer_span_when_overlapping`
  - `test_should_keep_non_overlapping_entities`
  - `test_should_resolve_partial_overlap`
  - `test_should_handle_empty_list`, `test_should_handle_single_entity`
  - `test_should_resolve_by_type_independently`
  - `test_should_check_overlap_types` (`_check_overlap` is untouched)
- [x] Max 5 files modified (2 files)
- [x] No protected files modified

## Details

### #1 — Overlap resolution

**Before:**
```python
for current in sorted_entities:
    should_keep = True
    remove_indices = []
    for i, kept_entity in enumerate(kept):     # ← O(n) inside O(n) loop
        overlap_type = self._check_overlap(kept_entity, current)
        if overlap_type == 'none':
            continue
        elif overlap_type == 'current_contains_kept':
            remove_indices.append(i)            # ← unreachable after the sort
        elif overlap_type in ('kept_contains_current', 'partial'):
            should_keep = False
            break
    for idx in reversed(remove_indices):
        kept.pop(idx)
    if should_keep:
        kept.append(current)
```

The docstring already claimed *"For each entity type, sort by position and apply a sweep-line approach. Complexity: O(n log n)"* — the implementation never matched the claim.

**After (true sweep-line):**
```python
for current in sorted_entities:
    if not kept:
        kept.append(current)
        continue
    last = kept[-1]
    if current.start >= last.end:    # disjoint → keep
        kept.append(current)
    # otherwise: contained or partial overlap → skip current
```

Why a single check against `kept[-1]` is sufficient is documented in the new docstring: the `(start, -length, -score)` sort makes the `current_contains_kept` branch unreachable, and the most recently kept entity covers the right-most accepted region for any later candidate.

### #2 — Presidio import

The previous `from ... import PresidioDetector` lived inside `_pass_fresh_configs_to_presidio`, paying the import-machinery cost on every gRPC request that carried fresh PII configs. Moving it to module scope (with the same `try/except` guard the file already uses for `GLiNERDetector`, `MultiPassGlinerDetector`, `CompositePIIDetector`, etc.) eliminates that cost; an explicit early-return now handles the case where the import fails.

### Impact
- Worst-case overlap resolution: O(n²) → O(n log n) per PII type.
- Per-request Presidio config hand-off: skips Python's import machinery on every call.

---
*Generated by Claude Code — autonomous continuous improvement*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened system reliability by implementing comprehensive safeguards that gracefully handle situations where optional detector components are unavailable or unconfigured, preventing service disruptions and failures.

* **Refactor**
  * Improved PII detection performance through enhanced and optimized overlap resolution logic, significantly reducing computational complexity and improving efficiency during scanning operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->