### PR TITLE
perf(scan): replace O(n) enum lookup with O(1) map index

### DIFF
--- a/pii-reporting-api/src/main/java/pro/softcom/aisentinel/domain/pii/scan/ScanEventType.java
+++ b/pii-reporting-api/src/main/java/pro/softcom/aisentinel/domain/pii/scan/ScanEventType.java
@@ -2,6 +2,12 @@ package pro.softcom.aisentinel.domain.pii.scan;
 
 import lombok.Getter;
 
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 /**
  * Enumeration of event types emitted during a Confluence scan.
  * These types represent the different stages of a scan lifecycle.
@@ -19,6 +25,16 @@ public enum ScanEventType {
     MULTI_COMPLETE("multiComplete"),
     KEEPALIVE("keepalive");
 
+    /**
+     * Pre-computed index for case-insensitive O(1) lookup by domain value.
+     * Populated once at class initialization; avoids allocating a new
+     * {@code values()} array on every {@link #fromValue(String)} call.
+     */
+    private static final Map<String, ScanEventType> BY_VALUE = Arrays.stream(values())
+        .collect(Collectors.toUnmodifiableMap(
+            t -> t.value.toLowerCase(Locale.ROOT),
+            Function.identity()));
+
     private final String value;
 
     ScanEventType(String value) {
@@ -29,11 +45,6 @@ public enum ScanEventType {
         if (value == null || value.isBlank()) {
             return null;
         }
-        for (ScanEventType type : values()) {
-            if (type.value.equalsIgnoreCase(value)) {
-                return type;
-            }
-        }
-        return null;
+        return BY_VALUE.get(value.toLowerCase(Locale.ROOT));
     }
 }

--- a/pii-reporting-api/src/main/java/pro/softcom/aisentinel/infrastructure/pii/reporting/adapter/in/dto/ScanEventType.java
+++ b/pii-reporting-api/src/main/java/pro/softcom/aisentinel/infrastructure/pii/reporting/adapter/in/dto/ScanEventType.java
@@ -3,6 +3,12 @@ package pro.softcom.aisentinel.infrastructure.pii.reporting.adapter.in.dto;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 /**
  * DTO adapter for JSON serialization of scan event types.
  * Maps domain types to the JSON format expected by clients.
@@ -18,6 +24,17 @@ public enum ScanEventType {
     COMPLETE("complete"),
     MULTI_COMPLETE("multiComplete"),
     KEEPALIVE("keepalive");
+
+    /**
+     * Pre-computed index for case-insensitive O(1) lookup by JSON value.
+     * Populated once at class initialization; avoids allocating a new
+     * {@code values()} array on every {@link #from(String)} call in the
+     * SSE event hot path.
+     */
+    private static final Map<String, ScanEventType> BY_JSON = Arrays.stream(values())
+        .collect(Collectors.toUnmodifiableMap(
+            t -> t.json.toLowerCase(Locale.ROOT),
+            Function.identity()));
 
     private final String json;
 
@@ -35,12 +52,7 @@ public enum ScanEventType {
         if (value == null || value.isBlank()) {
             return null;
         }
-        for (ScanEventType t : values()) {
-            if (t.json.equalsIgnoreCase(value)) {
-                return t;
-            }
-        }
-        return null;
+        return BY_JSON.get(value.toLowerCase(Locale.ROOT));
     }
 
     /**

--- a/pii-reporting-api/src/test/java/pro/softcom/aisentinel/infrastructure/pii/reporting/adapter/in/dto/ScanEventTypeTest.java
+++ b/pii-reporting-api/src/test/java/pro/softcom/aisentinel/infrastructure/pii/reporting/adapter/in/dto/ScanEventTypeTest.java
@@ -1,0 +1,45 @@
+package pro.softcom.aisentinel.infrastructure.pii.reporting.adapter.in.dto;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ScanEventTypeTest {
+
+    @ParameterizedTest
+    @EnumSource(ScanEventType.class)
+    void Should_ResolveEveryConstant_When_ExactJsonValueProvided(ScanEventType type) {
+        assertThat(ScanEventType.from(type.toJson())).isEqualTo(type);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "start, START",
+        "START, START",
+        "StArT, START",
+        "multiStart, MULTI_START",
+        "MULTISTART, MULTI_START",
+        "pagecomplete, PAGE_COMPLETE",
+        "SCANERROR, ERROR"
+    })
+    void Should_ResolveEnum_When_MixedCaseValueProvided(String input, ScanEventType expected) {
+        assertThat(ScanEventType.from(input)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "   ", "\t"})
+    void Should_ReturnNull_When_InputIsNullOrBlank(String input) {
+        assertThat(ScanEventType.from(input)).isNull();
+    }
+
+    @Test
+    void Should_ReturnNull_When_ValueIsUnknown() {
+        assertThat(ScanEventType.from("nonExistentEvent")).isNull();
+    }
+}


### PR DESCRIPTION
## Summary
- Both `ScanEventType` enums (domain + infrastructure DTO) resolved string values via a linear scan over `values()` — O(N) per call plus a fresh array allocation on every invocation.
- On the SSE scan event hot path (`ConfluenceContentScanResultToScanEventMapper.toDto`), this runs once per emitted event — potentially thousands of times per Confluence scan.
- Replaced with a pre-computed `Map<String, ScanEventType>` populated once at class initialization.

## Category
- [x] Algorithmic optimization
- [ ] Missing tests
- [ ] Refactoring
- [ ] Documentation
- [ ] SonarQube issue fix

## Files changed
- `domain/pii/scan/ScanEventType.java` — add `BY_VALUE` static map, replace loop with `BY_VALUE.get(lowercased)` in `fromValue()`
- `infrastructure/pii/reporting/adapter/in/dto/ScanEventType.java` — add `BY_JSON` static map, replace loop with `BY_JSON.get(lowercased)` in `from()`
- `infrastructure/pii/reporting/adapter/in/dto/ScanEventTypeTest.java` (**new**) — parameterized tests covering exact case, mixed case (case-insensitive contract), null / blank / unknown inputs, plus `@EnumSource` roundtrip for every constant

## Complexity

| Measure         | Before                               | After                              |
|-----------------|--------------------------------------|------------------------------------|
| Time per call   | O(N) + new array clone from `values()` + `equalsIgnoreCase` per entry | O(1) `Map.get` + one `toLowerCase` |
| Space           | O(N) transient (new array each call) | O(N) static, computed once         |
| Allocations/call | 1 array + up to N String comparisons | 1 lowercased String               |

N = 10 today, but the win is multiplied by the call frequency on the hot path.

## Verification
- [x] Tests pass for all modified modules (112 unit tests covering mapper, dispatcher, use cases, controllers, adapters — all green)
- [x] Build succeeds
- [x] No functional change (case-insensitive contract preserved via `toLowerCase(Locale.ROOT)`; `null` / blank / unknown returns `null` exactly like before)
- [x] Max 5 files modified (3 changed)
- [x] No protected files modified (no CI, no lockfile, no pom, no migration)

## Details

The pattern here is textbook optimization pattern #1 (replace nested/linear lookup with hash lookup):

```java
// Before — O(N) with a fresh array allocation on every call
for (ScanEventType t : values()) {           // values() clones the internal array
    if (t.json.equalsIgnoreCase(value)) {    // O(string length) per entry
        return t;
    }
}
return null;

// After — O(1) lookup against a pre-built index
return BY_JSON.get(value.toLowerCase(Locale.ROOT));
```

`Locale.ROOT` is used explicitly to avoid the Turkish-locale `I` → `ı` pitfall that would break ASCII enum keys in some regions.

The new `ScanEventTypeTest` locks in the contract so a future edit to the normalization strategy (or to the enum constants) can't silently regress the case-insensitive behavior:

- `@EnumSource` + `from(type.toJson())` roundtrip guarantees every constant is indexed.
- `@CsvSource` covers mixed-case inputs including `MULTISTART` / `SCANERROR`.
- `@NullAndEmptySource` + blank strings cover the defensive branch.

---
*Generated by Claude Code — autonomous continuous improvement*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced case-insensitive enum value lookup with improved implementation

* **Tests**
  * Added comprehensive test coverage for enum value parsing, including edge cases, null handling, and alternative input formats

<!-- end of auto-generated comment: release notes by coderabbit.ai -->