### PR TITLE
perf(detector): linearise _apply_masks from O(n·len(text)) to O(n+len(text))

### DIFF
--- a/pii-detector-service/pii_detector/infrastructure/detector/pii_detector.py
+++ b/pii-detector-service/pii_detector/infrastructure/detector/pii_detector.py
@@ -370,15 +370,40 @@ class PIIDetector:
             return [[] for _ in batch]
 
     def _apply_masks(self, text: str, entities: List[PIIEntity]) -> str:
-        """Apply masks to detected PII entities."""
-        entities_sorted = sorted(entities, key=lambda x: x.start, reverse=True)
-        masked_text = text
+        """Apply masks to detected PII entities.
 
+        Builds the output in a single left-to-right pass with a parts buffer
+        joined at the end. The previous implementation sliced and
+        concatenated ``masked_text`` inside a loop, which is O(n × len(text))
+        because Python strings are immutable — each iteration allocates a new
+        string the size of the full text. This variant is O(n + len(text))
+        and also matches the implementation already used in
+        ``gliner_detector.py``.
+
+        Overlapping entities (``entity.start < last_pos``) are skipped instead
+        of corrupting the output, making the method safer than the previous
+        right-to-left slicing which silently dropped masks when indices
+        shifted.
+        """
+        if not entities:
+            return text
+
+        entities_sorted = sorted(entities, key=lambda x: x.start)
+
+        parts: List[str] = []
+        last_pos = 0
         for entity in entities_sorted:
-            mask = f"[{entity.pii_type}]"
-            masked_text = masked_text[:entity.start] + mask + masked_text[entity.end:]
+            if entity.start < last_pos:
+                # Overlap with the previous accepted entity — skip to avoid
+                # corrupt output. Dedupe (_post_process_entities) should
+                # normally prevent this case.
+                continue
+            parts.append(text[last_pos:entity.start])
+            parts.append(f"[{entity.pii_type}]")
+            last_pos = entity.end
 
-        return masked_text
+        parts.append(text[last_pos:])
+        return "".join(parts)
 
     def _is_duplicate_entity(self, entity: PIIEntity, existing_entities: List[PIIEntity]) -> bool:
         """Check if an entity with the same span and type already exists."""


### PR DESCRIPTION
## Summary
- Replace the slice-and-concat loop in `PIIDetector._apply_masks` with a left-to-right parts buffer joined once at the end
- Align implementation with `GLiNERDetector._apply_masks`, which already uses the linear approach

## Category
- [x] Algorithmic optimization
- [ ] Missing tests
- [ ] Refactoring
- [ ] Documentation
- [ ] SonarQube issue fix

## Files changed
- `pii-detector-service/pii_detector/infrastructure/detector/pii_detector.py`

## Verification
- [x] Python syntax OK (`python -m py_compile`)
- [x] Existing tests preserved:
  - `test_should_mask_pii_entities` — non-overlapping masks
  - `test_should_mask_overlapping_entities_correctly` — adjacent spans `[2,5]` + `[5,8]` produce `01[A][B]89` in both the old and the new implementation
- [x] Max 5 files modified (1 file)
- [x] No protected files modified

## Details

### Problem
```python
def _apply_masks(self, text: str, entities: List[PIIEntity]) -> str:
    entities_sorted = sorted(entities, key=lambda x: x.start, reverse=True)
    masked_text = text
    for entity in entities_sorted:
        mask = f"[{entity.pii_type}]"
        masked_text = masked_text[:entity.start] + mask + masked_text[entity.end:]
    return masked_text
```

Python strings are immutable, so `masked_text[:a] + mask + masked_text[b:]` allocates a brand-new string of size `~len(masked_text)` on every iteration. For `n` entities on a text of length `T` that is `O(n·T)` total.

On a 10 000-character page with 100 detections that is ~1 million byte-copy operations per call — and `_apply_masks` is on the synchronous response path of every `DetectPII` gRPC request.

### Fix
```python
entities_sorted = sorted(entities, key=lambda x: x.start)
parts: List[str] = []
last_pos = 0
for entity in entities_sorted:
    if entity.start < last_pos:
        continue  # defensive: skip overlapping residue
    parts.append(text[last_pos:entity.start])
    parts.append(f"[{entity.pii_type}]")
    last_pos = entity.end
parts.append(text[last_pos:])
return "".join(parts)
```

One forward pass builds a list of slices and masks; `"".join` is O(T). Total cost is `O(n + T)` — linear in both inputs instead of their product.

Additional benefit: the previous right-to-left slicing silently dropped masks when entities truly overlapped (shifted indices made `text[end:]` return an empty string). The new implementation explicitly detects overlap (`entity.start < last_pos`) and skips the offending entity instead of corrupting the output.

### Impact
For a 10 000-char page and 100 entities:
- **Before:** ~1 000 000 char-copies per call
- **After:** ~10 100 char-copies per call (≈100× fewer)

This matches the implementation that already ships in `GLiNERDetector._apply_masks`, so both detector code paths are now consistent.

---
*Generated by Claude Code — autonomous continuous improvement*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved PII masking algorithm performance through optimized processing logic and enhanced overlap handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->