### PR TITLE
fix(detector): CompositePIIDetector ml_count misread when ML disabled at request time

### DIFF
--- a/pii-detector-service/pii_detector/application/orchestration/composite_detector.py
+++ b/pii-detector-service/pii_detector/application/orchestration/composite_detector.py
@@ -209,47 +209,45 @@ class CompositePIIDetector:
             detectors_str = ', '.join(active_detectors) if active_detectors else 'NONE'
             self.logger.debug("Detecting PII with active detectors: %s", detectors_str)
         
-        # Collect results from all detectors
+        # Collect results from all detectors and track per-detector counts
+        # at the source — avoids a post-hoc linear scan and also fixes the
+        # earlier ml_count bug that read from `results_per_detector[0]`
+        # (which was only ML when `use_ml` was True).
         results_per_detector: List[Tuple[PIIDetectorProtocol, List[PIIEntity]]] = []
-        
+        ml_count = 0
+        regex_count = 0
+        presidio_count = 0
+
         # Execute ML detection
         if use_ml and self.ml_detector:
             ml_entities = self._run_ml_detection(text, threshold, pii_type_configs, chunk_size)
             results_per_detector.append((self.ml_detector, ml_entities))
-        
+            ml_count = len(ml_entities)
+
         # Execute regex detection
         if use_regex and self.regex_detector:
             regex_entities = self._run_regex_detection(text, threshold)
             results_per_detector.append((self.regex_detector, regex_entities))
-        
+            regex_count = len(regex_entities)
+
         # Execute Presidio detection
         if use_presidio and self.presidio_detector:
             presidio_entities = self._run_presidio_detection(text, threshold)
             results_per_detector.append((self.presidio_detector, presidio_entities))
-        
+            presidio_count = len(presidio_entities)
+
         # Merge results
         if not results_per_detector:
             self.logger.warning("No detectors available")
             return []
-        
+
         merged_entities = self._merger.merge(results_per_detector)
-        
-        # Count entities per detector for logging
-        ml_count = len(results_per_detector[0][1]) if self.ml_detector else 0
-        regex_count = 0
-        presidio_count = 0
-        
-        for detector, entities in results_per_detector:
-            if detector == self.regex_detector:
-                regex_count = len(entities)
-            elif detector == self.presidio_detector:
-                presidio_count = len(entities)
-        
+
         self.logger.info(
             f"Composite detection complete: {len(merged_entities)} entities "
             f"(ML: {ml_count}, Regex: {regex_count}, Presidio: {presidio_count})"
         )
-        
+
         return merged_entities
     
     def mask_pii(


### PR DESCRIPTION
## Summary
- Fix incorrect `ml_count` reported by `CompositePIIDetector.detect_pii` when ML is disabled for a specific request
- Eliminate the redundant post-hoc scan over `results_per_detector` by tracking counts where each detector actually runs

## Category
- [x] Algorithmic optimization
- [ ] Missing tests
- [ ] Refactoring
- [x] Documentation (diagnostic log)
- [x] SonarQube issue fix (silent logging bug)

## Files changed
- `pii-detector-service/pii_detector/application/orchestration/composite_detector.py` — track counts at detection time; drop the second `for detector, entities in results_per_detector` scan

## Verification
- [x] Python syntax OK (`python -m py_compile`)
- [x] No test references `ml_count` / `regex_count` / `presidio_count` or the "Composite detection complete" log line — safe behavioural change
- [x] Max 5 files modified (1 file)
- [x] No protected files modified

## Details

### Bug
```python
ml_count = len(results_per_detector[0][1]) if self.ml_detector else 0
```

`self.ml_detector` is the **attribute** — kept loaded in memory for runtime activation. But each request can selectively disable ML via `use_ml`:

```python
if use_ml and self.ml_detector:
    results_per_detector.append((self.ml_detector, ml_entities))
```

So when `use_ml=False` and `self.ml_detector` is not `None`, ML is **not** at index 0 — regex or Presidio is. The logged `ml_count` then reports those other detectors' counts under the "ML" label, silently corrupting diagnostics.

### Fix
Track the three counts at the call site where each detection happens:

```python
ml_count = regex_count = presidio_count = 0

if use_ml and self.ml_detector:
    ml_entities = self._run_ml_detection(...)
    results_per_detector.append((self.ml_detector, ml_entities))
    ml_count = len(ml_entities)
# ... same for regex / presidio
```

The second loop (`for detector, entities in results_per_detector: if detector == ...`) becomes unnecessary and is removed.

### Impact
- Correct per-detector telemetry in the "Composite detection complete" log line.
- One fewer O(detectors) scan per request (cosmetic; detectors ≤ 3).

---
*Generated by Claude Code — autonomous continuous improvement*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal detection counting logic in the PII detector service for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->