### PR TITLE
perf(crypto): cache JCA Cipher and Mac via ThreadLocal

### DIFF
--- a/pii-reporting-api/src/main/java/pro/softcom/aisentinel/infrastructure/pii/reporting/adapter/out/AesGcmEncryptionAdapter.java
+++ b/pii-reporting-api/src/main/java/pro/softcom/aisentinel/infrastructure/pii/reporting/adapter/out/AesGcmEncryptionAdapter.java
@@ -11,10 +11,12 @@ import pro.softcom.aisentinel.infrastructure.pii.reporting.adapter.out.config.En
 
 import javax.crypto.Cipher;
 import javax.crypto.Mac;
+import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Base64;
@@ -57,6 +59,38 @@ public class AesGcmEncryptionAdapter implements EncryptionService {
 
     // HKDF context
     private static final byte[] HKDF_INFO_DEK = "pii-encryption-dek".getBytes(StandardCharsets.UTF_8);
+
+    /**
+     * Per-thread cached {@link Cipher} instance for {@value #CIPHER_ALGORITHM}.
+     * <p>The JCA {@code Cipher.getInstance} lookup traverses the registered
+     * security providers and is non-trivial in the encrypt/decrypt hot path
+     * (called once per detected PII entity). Cipher is not thread-safe, so a
+     * static singleton is unsound — {@link ThreadLocal} is the canonical JCA
+     * pattern. Each {@code init(...)} call fully resets the internal state,
+     * so no secret or cryptographic material leaks between invocations.</p>
+     */
+    private static final ThreadLocal<Cipher> CIPHER_POOL = ThreadLocal.withInitial(() -> {
+        try {
+            return Cipher.getInstance(CIPHER_ALGORITHM);
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
+            throw new IllegalStateException(
+                "JCA provider does not support " + CIPHER_ALGORITHM, e);
+        }
+    });
+
+    /**
+     * Per-thread cached {@link Mac} instance for {@value #HKDF_MAC_ALGORITHM}.
+     * Same reasoning as {@link #CIPHER_POOL}: {@code Mac} is not thread-safe
+     * and is re-initialized with a fresh key on every use.
+     */
+    private static final ThreadLocal<Mac> MAC_POOL = ThreadLocal.withInitial(() -> {
+        try {
+            return Mac.getInstance(HKDF_MAC_ALGORITHM);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(
+                "JCA provider does not support " + HKDF_MAC_ALGORITHM, e);
+        }
+    });
 
     private final SecretKey key;
     private final SecureRandom secureRandom = new SecureRandom();
@@ -127,7 +161,7 @@ public class AesGcmEncryptionAdapter implements EncryptionService {
     private byte[] hkdf(byte[] ikm, byte[] salt) throws CryptographicOperationException {
         try {
             // Extract: PRK = HMAC(salt, IKM)
-            Mac mac = Mac.getInstance(HKDF_MAC_ALGORITHM);
+            Mac mac = MAC_POOL.get();
             mac.init(new SecretKeySpec(salt, HKDF_MAC_ALGORITHM));
             byte[] prk = mac.doFinal(ikm);
 
@@ -179,7 +213,7 @@ public class AesGcmEncryptionAdapter implements EncryptionService {
      */
     private byte[] encryptWithGcm(byte[] dek, byte[] iv, byte[] aad, String plaintext) throws CryptographicOperationException {
         try {
-            Cipher cipher = Cipher.getInstance(CIPHER_ALGORITHM);
+            Cipher cipher = CIPHER_POOL.get();
             GCMParameterSpec spec = new GCMParameterSpec(GCM_TAG_LENGTH, iv);
             SecretKey dekKey = new SecretKeySpec(dek, "AES");
             cipher.init(Cipher.ENCRYPT_MODE, dekKey, spec);
@@ -195,7 +229,7 @@ public class AesGcmEncryptionAdapter implements EncryptionService {
      */
     private byte[] decryptWithGcm(byte[] dek, byte[] iv, byte[] aad, byte[] ciphertext) throws CryptographicOperationException {
         try {
-            Cipher cipher = Cipher.getInstance(CIPHER_ALGORITHM);
+            Cipher cipher = CIPHER_POOL.get();
             GCMParameterSpec spec = new GCMParameterSpec(GCM_TAG_LENGTH, iv);
             SecretKey dekKey = new SecretKeySpec(dek, "AES");
             cipher.init(Cipher.DECRYPT_MODE, dekKey, spec);


### PR DESCRIPTION
## Summary
- `AesGcmEncryptionAdapter` did three JCA provider lookups per PII encrypt/decrypt (`Cipher.getInstance` in `encryptWithGcm` + `decryptWithGcm`, `Mac.getInstance` in `hkdf`).
- On a scan, each detected entity triggers the encrypt path through `ScanResultEncryptor` — the JCA lookup dominates the CPU cost for short payloads (names, emails, phone numbers).
- Cached the `Cipher` and `Mac` instances per thread via `ThreadLocal`. `init(...)` is still called on every use, which fully resets internal state — no secret / cryptographic material leaks between invocations.

## Category
- [x] Algorithmic optimization
- [ ] Missing tests
- [ ] Refactoring
- [ ] Documentation
- [ ] SonarQube issue fix

## Files changed
- `infrastructure/pii/reporting/adapter/out/AesGcmEncryptionAdapter.java` — add `CIPHER_POOL` / `MAC_POOL` `ThreadLocal` fields, replace `Cipher.getInstance` / `Mac.getInstance` with `.get()`

## Complexity

| Measure            | Before                                            | After                                         |
|--------------------|---------------------------------------------------|-----------------------------------------------|
| Per-call work      | 3 × JCA provider traversal + `getInstance` alloc  | 3 × `ThreadLocal.get()` (O(1), no allocation) |
| Per-thread memory  | —                                                 | 1 `Cipher` + 1 `Mac` (cheap)                  |
| Correctness        | ok                                                | ok (`init(...)` resets state on every use)    |
| Thread-safety      | implicit (new instance per call)                  | explicit (per-thread instance, never shared)  |

## Why not a static singleton?
`javax.crypto.Cipher` and `javax.crypto.Mac` are **not** thread-safe. Two concurrent threads sharing one instance would corrupt each other's keys / IVs / internal buffers — a crypto correctness bug, potentially a security bug. `ThreadLocal` is the canonical JCA caching pattern precisely for this reason.

## Why not a pool?
`ThreadLocal` is a single-entry pool keyed by thread, and it's lock-free. A proper object pool would add contention (queue + wait) that dwarfs the savings, and it doesn't fit the usage: encrypt/decrypt happens inside the request thread and doesn't escape it.

## Verification
- [x] `AesGcmEncryptionAdapterTest` passes (17 tests: roundtrip, unicode, long text, GCM tamper, salt tamper, AAD binding, null metadata, format check)
- [x] `ScanResultEncryptorTest` passes (12 tests — the actual hot path consumer)
- [x] `ScanReportingUseCaseTest` passes (5 tests)
- [x] `RevealPiiSecretsUseCaseTest` passes (3 tests — `/reveal` decrypt path)
- [x] Build succeeds
- [x] No functional change (behavior-preserving)
- [x] Max 5 files modified (1 changed)
- [x] No protected files modified

## Security notes
- `ThreadLocal` stores a `Cipher` / `Mac` instance. Neither holds secret material after a use — the `SecretKey` is passed to `init(...)` per call and is not retained by the cipher state after `doFinal()` completes.
- No classloader leak risk for typical Spring Boot / Tomcat layouts: the `ThreadLocal` reference is held by a class loaded by the application classloader, and the webcontainer thread pool belongs to the same scope.
- `wipeMemory()` on the derived DEK bytes continues to run unchanged in the `finally` block.

---
*Generated by Claude Code — autonomous continuous improvement*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced performance of encryption and key-derivation operations through optimized resource management and caching strategies for cryptographic components, reducing overhead from repeated object initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->