### PR TITLE
perf(scan): O(N) Set lookup instead of O(N*M) List.contains in space filter

### DIFF
--- a/pii-reporting-api/src/main/java/pro/softcom/aisentinel/application/pii/reporting/usecase/StreamConfluenceScanUseCase.java
+++ b/pii-reporting-api/src/main/java/pro/softcom/aisentinel/application/pii/reporting/usecase/StreamConfluenceScanUseCase.java
@@ -15,8 +15,10 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.time.Instant;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -170,14 +172,17 @@ public class StreamConfluenceScanUseCase extends AbstractStreamConfluenceScanUse
     }
 
     private Flux<ConfluenceContentScanResult> buildSelectedSpaceScanFluxBody(String scanId, List<String> spaceKeys) {
+        // Build an O(1) index up front to avoid an O(allSpaces × spaceKeys) List.contains
+        // when filtering. Confluence instances can expose hundreds of spaces.
+        Set<String> selectedKeys = new HashSet<>(spaceKeys);
         // Asynchronous retrieval of all spaces (Future -> Mono)
         // Optimization: We could fetch only specific spaces if the API supported it, but filtering is safe.
         return Mono.fromFuture(confluenceAccessor.getAllSpaces())
             // Then unfold into Flux<ScanResult>
             .flatMapMany(allSpaces -> {
-                // Filter spaces based on provided keys
+                // Filter spaces based on provided keys (O(1) lookup per space)
                 List<ConfluenceSpace> selectedSpaces = allSpaces.stream()
-                    .filter(space -> spaceKeys.contains(space.key()))
+                    .filter(space -> selectedKeys.contains(space.key()))
                     .toList();
 
                 // If the list is empty, generate a small error Flux. Otherwise, create the scan Flux.


### PR DESCRIPTION
## Summary
- `buildSelectedSpaceScanFluxBody` filtered `allSpaces` with `spaceKeys.contains(space.key())`. Since `spaceKeys` is a `List<String>`, each `contains` call is O(M), giving an overall O(N × M) for the selection step.
- N = number of Confluence spaces returned by the API (can grow to hundreds on a real instance), M = number of selected keys submitted by the user.
- Built a `HashSet<String>` from `spaceKeys` once, then used `Set.contains` (O(1) per element) → overall O(N + M).

## Category
- [x] Algorithmic optimization
- [ ] Missing tests
- [ ] Refactoring
- [ ] Documentation
- [ ] SonarQube issue fix

## Files changed
- `application/pii/reporting/usecase/StreamConfluenceScanUseCase.java` — add `HashSet` / `Set` imports, materialize `selectedKeys` before subscribing, switch the filter to use it

## Complexity

| Measure | Before | After |
|---------|--------|-------|
| Filter step | O(N × M) per scan | O(N + M) per scan |
| Allocation | none upfront | one `HashSet` of size M |

For an instance with 200 spaces and a selection of 30 keys, the comparison drops from ~6,000 to ~230 ops on the pre-scan filter. Negligible in absolute terms, but in line with the project's continuous-improvement direction (eliminate accidental quadratic behavior on user-controlled inputs).

## Why build the Set outside the lambda?
The `flatMapMany` callback runs once per Mono emission, but `Mono.fromFuture` only emits once. Building the Set up front (in the use case body) makes it explicit that the index is constructed once and captured by the closure — it also makes the optimization visible at the method's top level rather than buried inside a reactive stage.

## Verification
- [x] `StreamConfluenceScanUseCaseTest` passes (18 tests covering selected-space filtering, error cases, multi-space orchestration)
- [x] Build succeeds
- [x] No functional change (filter semantics preserved — `Set.contains(null)` and `List.contains(null)` behave identically here)
- [x] Max 5 files modified (1 changed)
- [x] No protected files modified

## Details
The closure capture pattern is intentional: `selectedKeys` is final and effectively immutable once built, so the lambda can reference it safely from the reactive stage. A defensive `Set.copyOf(spaceKeys)` was considered but `HashSet` (mutable) is simpler and the lambda only reads from it.

---
*Generated by Claude Code — autonomous continuous improvement*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized space filtering performance in PII reporting scans through improved lookup mechanisms, maintaining existing functionality while reducing processing overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->