### PR TITLE
perf(regex-detector): linearise _apply_masks O(n·T) → O(n+T)

### DIFF
--- a/pii-detector-service/pii_detector/infrastructure/detector/regex_detector.py
+++ b/pii-detector-service/pii_detector/infrastructure/detector/regex_detector.py
@@ -450,22 +450,40 @@ class RegexDetector:
     def _apply_masks(self, text: str, entities: List[PIIEntity]) -> str:
         """
         Apply masks to detected entities.
-        
+
+        Builds the output in a single left-to-right pass with a parts buffer
+        joined at the end. The previous implementation sliced and concatenated
+        ``masked_text`` inside a loop, which is O(n × len(text)) because
+        Python strings are immutable — each iteration allocates a fresh
+        string the size of the full text. This variant is O(n + len(text))
+        and matches the implementation already used in
+        ``GLiNERDetector._apply_masks`` / ``PIIDetector._apply_masks``.
+
+        Overlapping entities (``entity.start < last_pos``) are defensively
+        skipped. ``_resolve_overlaps`` normally guarantees no overlap, but a
+        skip is safer than the previous right-to-left slicing which silently
+        dropped masks when indices shifted.
+
         Args:
             text: Original text
             entities: Detected entities
-            
+
         Returns:
             Masked text
         """
-        # Sort by position (reverse order for replacement)
-        sorted_entities = sorted(entities, key=lambda x: x.start, reverse=True)
-        
-        masked_text = text
+        if not entities:
+            return text
+
+        sorted_entities = sorted(entities, key=lambda x: x.start)
+
+        parts: List[str] = []
+        last_pos = 0
         for entity in sorted_entities:
-            mask = f"[{entity.pii_type}]"
-            masked_text = (
-                masked_text[:entity.start] + mask + masked_text[entity.end:]
-            )
-        
-        return masked_text
+            if entity.start < last_pos:
+                continue
+            parts.append(text[last_pos:entity.start])
+            parts.append(f"[{entity.pii_type}]")
+            last_pos = entity.end
+
+        parts.append(text[last_pos:])
+        return "".join(parts)


### PR DESCRIPTION
## Summary
- Fix the third (and last) occurrence of the slice-and-concat-in-loop masking anti-pattern in the PII detector service, this time in `RegexDetector._apply_masks`
- Aligns all three detector implementations (`PIIDetector`, `GLiNERDetector`, `RegexDetector`) on the same linear-time algorithm

## Category
- [x] Algorithmic optimization
- [ ] Missing tests
- [ ] Refactoring
- [ ] Documentation
- [ ] SonarQube issue fix

## Files changed
- `pii-detector-service/pii_detector/infrastructure/detector/regex_detector.py`

## Verification
- [x] Python syntax OK (`python -m py_compile`)
- [x] Existing tests preserved:
  - `test_Should_MaskPII_When_DetectedEntities` — MAC address masking
  - `test_Should_PreservePositions_When_Masking` — multi-type masking with structure preservation
- [x] Max 5 files modified (1 file)
- [x] No protected files modified
- [x] Complements PRs #81 (`PIIDetector._apply_masks`) and pre-existing optimised `GLiNERDetector._apply_masks`

## Details

### Problem
```python
entities_sorted = sorted(entities, key=lambda x: x.start, reverse=True)
masked_text = text
for entity in entities_sorted:
    mask = f"[{entity.pii_type}]"
    masked_text = masked_text[:entity.start] + mask + masked_text[entity.end:]
return masked_text
```

Python strings are immutable — every `masked_text[:a] + mask + masked_text[b:]` allocates a brand-new string the size of the full text. For `n` entities on a text of length `T`, total cost is `O(n · T)`.

### Fix
```python
sorted_entities = sorted(entities, key=lambda x: x.start)
parts: List[str] = []
last_pos = 0
for entity in sorted_entities:
    if entity.start < last_pos:
        continue  # defensive: _resolve_overlaps already removes overlaps
    parts.append(text[last_pos:entity.start])
    parts.append(f"[{entity.pii_type}]")
    last_pos = entity.end
parts.append(text[last_pos:])
return "".join(parts)
```

One forward pass builds a list of slices and masks; `"".join` is O(T). Total is `O(n + T)`.

### Impact
Consistency: the three detector `_apply_masks` implementations now share the same linear algorithm. Previously, invoking regex detection on a large document produced O(n · T) mask rebuilding while the ML detector (after PR #81) ran in O(n + T).

For a 10 000-char page and 100 regex entities:
- **Before:** ~1 000 000 char-copies per call
- **After:** ~10 100 char-copies per call (≈100× fewer)

---
*Generated by Claude Code — autonomous continuous improvement*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized PII masking performance through improved text processing and entity handling logic.
  * Enhanced reliability of text masking to better handle edge cases in entity processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->