### PR TITLE
perf(multi-detector): linearise mask_pii O(n*T) to O(n+T)

### DIFF
--- a/pii-detector-service/pii_detector/application/orchestration/multi_detector.py
+++ b/pii-detector-service/pii_detector/application/orchestration/multi_detector.py
@@ -251,13 +251,37 @@ class MultiModelPIIDetector:
 
     def mask_pii(self, text: str, threshold: Optional[float] = None) -> Tuple[str, List[PIIEntity]]:
         entities = self.detect_pii(text, threshold)
-        # Apply masking in descending order of start index to preserve spans
-        entities_sorted = sorted(entities, key=lambda x: x.start, reverse=True)
-        masked_text = text
-        for entity in entities_sorted:
-            mask = f"[{entity.pii_type}]"
-            masked_text = masked_text[: entity.start] + mask + masked_text[entity.end :]
+        masked_text = self._apply_masks(text, entities)
         return masked_text, entities
+
+    def _apply_masks(self, text: str, entities: List[PIIEntity]) -> str:
+        """Rebuild masked text in a single O(n + len(text)) pass.
+
+        Previously the method rewrote ``masked_text`` inside a loop using
+        ``masked_text[:a] + mask + masked_text[b:]``. Python strings are
+        immutable so every iteration allocated a fresh string the size of
+        the whole document — O(n · len(text)) for n detected entities.
+
+        Build a list of slices and masks instead, joined once at the end.
+        Overlapping entities are defensively skipped; ``DetectionMerger``
+        already removes them upstream, so this is purely a safety net.
+        """
+        if not entities:
+            return text
+
+        entities_sorted = sorted(entities, key=lambda x: x.start)
+
+        parts: List[str] = []
+        last_pos = 0
+        for entity in entities_sorted:
+            if entity.start < last_pos:
+                continue
+            parts.append(text[last_pos:entity.start])
+            parts.append(f"[{entity.pii_type}]")
+            last_pos = entity.end
+
+        parts.append(text[last_pos:])
+        return "".join(parts)
 
     @property
     def model_id(self) -> str:


### PR DESCRIPTION
## Summary
- Fix the 5th and final occurrence of the slice-and-concat-in-loop masking anti-pattern, inlined in `MultiModelPIIDetector.mask_pii`
- Extract a dedicated `_apply_masks` helper, aligning with the four sibling detector implementations

## Category
- [x] Algorithmic optimization
- [ ] Missing tests
- [ ] Refactoring
- [ ] Documentation
- [ ] SonarQube issue fix

## Files changed
- `pii-detector-service/pii_detector/application/orchestration/multi_detector.py`

## Verification
- [x] Python syntax OK
- [x] Existing test preserved: `test_should_mask_detected_entities`
- [x] Max 5 files modified (1 file)
- [x] No protected files modified

## Details

All five masking implementations across `pii-detector-service` now share the same linear O(n+T) algorithm:

| Class | Status |
|---|---|
| PIIDetector._apply_masks | Fixed in PR #81 |
| GLiNERDetector._apply_masks | Already optimal pre-audit |
| CompositePIIDetector._apply_masks | Already optimal pre-audit |
| RegexDetector._apply_masks | Fixed in PR #85 |
| MultiModelPIIDetector.mask_pii | **This PR** |

For 10 000-char page and 100 entities: approximately 1M char-copies before, 10k after (approx. 100x fewer).

---
*Generated by Claude Code*