### PR TITLE
perf(event): hoist lightweight PII list out of per-entity mapping

### DIFF
--- a/pii-reporting-api/src/main/java/pro/softcom/aisentinel/application/pii/reporting/service/ScanEventFactory.java
+++ b/pii-reporting-api/src/main/java/pro/softcom/aisentinel/application/pii/reporting/service/ScanEventFactory.java
@@ -206,43 +206,49 @@ public class ScanEventFactory {
 
     /**
      * Maps PII detection results to entity list for event payload.
+     * <p>
+     * Builds a lightweight view of all detected PIIs once up front so that
+     * each call to {@link #mapSensitiveDataToEntity} can reuse it for
+     * cross-line context masking — avoiding a quadratic allocation that
+     * rebuilt the same N-element list for every one of the N detected PIIs.
      */
     private List<DetectedPersonallyIdentifiableInformation> mapToEntityList(
         ContentPiiDetection detection, String content) {
         if (detection == null || detection.sensitiveDataFound() == null) {
             return List.of();
         }
-        return detection.sensitiveDataFound().stream()
-            .map(sensitiveData -> this.mapSensitiveDataToEntity(sensitiveData, content, detection))
+        List<DetectedPersonallyIdentifiableInformation> lightweightAll = detection.sensitiveDataFound().stream()
+            .map(ScanEventFactory::toLightweightEntity)
             .toList();
+        return detection.sensitiveDataFound().stream()
+            .map(sensitiveData -> this.mapSensitiveDataToEntity(sensitiveData, content, lightweightAll))
+            .toList();
+    }
+
+    /**
+     * Lightweight projection used when masking other PIIs that share the same
+     * line as the principal one: only positions and type are needed.
+     */
+    private static DetectedPersonallyIdentifiableInformation toLightweightEntity(
+        ContentPiiDetection.SensitiveData sd) {
+        String sdType = sd.type() != null ? sd.type().name() : null;
+        return DetectedPersonallyIdentifiableInformation.builder()
+            .startPosition(sd.position())
+            .endPosition(sd.end())
+            .piiType(sdType)
+            .build();
     }
 
     private DetectedPersonallyIdentifiableInformation mapSensitiveDataToEntity(
         ContentPiiDetection.SensitiveData data, String sourceContent,
-        ContentPiiDetection detection) {
+        List<DetectedPersonallyIdentifiableInformation> lightweightAll) {
         String type = (data.type() != null ? data.type().name() : null);
         String typeLabel = (data.type() != null ? data.type().getLabel() : null);
-        // Build a lightweight list of entities to ensure other PIIs in the same line are also masked in context
-        List<DetectedPersonallyIdentifiableInformation> all =
-            detection == null || detection.sensitiveDataFound() == null ? List.of() :
-                detection.sensitiveDataFound().stream()
-                    .map(sd -> {
-                        String sdType = null;
-                        if (sd.type() != null) {
-                            sdType = sd.type().name();
-                        }
-                        return DetectedPersonallyIdentifiableInformation.builder()
-                            .startPosition(sd.position())
-                            .endPosition(sd.end())
-                            .piiType(sdType)
-                            .build();
-                    })
-                    .toList();
 
         // Extract masked context (for immediate display, stored in clear)
         String maskedContext = piiContextExtractor.extractMaskedContext(sourceContent,
                                                                         data.position(), data.end(),
-                                                                        type, all);
+                                                                        type, lightweightAll);
 
         // Extract real context (contains actual PII values, will be encrypted)
         String sensitiveContext = piiContextExtractor.extractSensitiveContext(sourceContent,


### PR DESCRIPTION
## Summary
- `ScanEventFactory.mapToEntityList` called `mapSensitiveDataToEntity` for each detected PII.
- Inside, every call rebuilt a lightweight `List<DetectedPersonallyIdentifiableInformation>` from **all** sensitiveData in the current detection — the same list, reconstructed once per entity.
- For a page with N PIIs, that's N calls × an N-element list = **O(N²) allocations** on the scan / SSE hot path.

## Category
- [x] Algorithmic optimization
- [ ] Missing tests
- [ ] Refactoring
- [ ] Documentation
- [ ] SonarQube issue fix

## Files changed
- `application/pii/reporting/service/ScanEventFactory.java` — extract `toLightweightEntity()` helper, build the lightweight list once in `mapToEntityList`, pass it into `mapSensitiveDataToEntity`

## Complexity

| Measure                         | Before                              | After                     |
|---------------------------------|-------------------------------------|---------------------------|
| Lightweight list builds / page  | N (one per PII)                     | 1                         |
| Total mapping work              | O(N²)                               | O(N)                      |
| Allocations per page (N PIIs)   | N × (N entities + N builder chains) | 1 × N + N builder chains  |

## Why it matters
This runs inside the scan emission path: every page produces one event through `ScanEventFactory` and the context masking needs the "who else is in the same line" view. Quadratic allocation pressure here translates directly into heap churn during bulk scans and noisy allocation profiles on SSE streams — a scan over a Confluence space with dense PII pages can multiply the GC load unnecessarily.

## Verification
- [x] `ContentScanOrchestratorTest` passes (4 tests across inner classes)
- [x] `PiiContextExtractorTest` passes (33 tests — the direct consumer of the lightweight list for cross-line masking)
- [x] `StreamConfluenceScanUseCaseTest` passes (18 tests)
- [x] `StreamConfluenceResumeScanUseCaseTest` passes (5 tests)
- [x] Build succeeds
- [x] No functional change — list content, ordering and semantics preserved; `null` / empty detection paths unchanged
- [x] Max 5 files modified (1 changed, 44 lines touched)
- [x] No protected files modified

## Notes
The `detection` parameter of `mapSensitiveDataToEntity` is dropped since it was only used to rebuild the lightweight list; all remaining code paths already had what they needed from `data`, `sourceContent`, and the precomputed list. This narrows the method's responsibility without changing behavior.

---
*Generated by Claude Code — autonomous continuous improvement*