### PR TITLE
chore(logging): replace 5 debug print() statements with logger calls

### DIFF
--- a/pii-detector-service/pii_detector/application/orchestration/composite_detector.py
+++ b/pii-detector-service/pii_detector/application/orchestration/composite_detector.py
@@ -21,18 +21,16 @@ from pii_detector.domain.port.pii_detector_protocol import PIIDetectorProtocol
 from pii_detector.domain.service.detection_merger import DetectionMerger
 from pii_detector.infrastructure.detector.regex_detector import RegexDetector
 
+logger = logging.getLogger(__name__)
+
 try:
     from pii_detector.infrastructure.detector.presidio_detector import PresidioDetector
     PRESIDIO_AVAILABLE = True
-    print("[PRESIDIO_IMPORT] SUCCESS - PresidioDetector imported successfully")
+    logger.info("PresidioDetector import: SUCCESS")
 except ImportError as e:
     PRESIDIO_AVAILABLE = False
     PresidioDetector = None
-    print(f"[PRESIDIO_IMPORT] FAILED - ImportError: {e}")
-    print(f"[PRESIDIO_IMPORT] PRESIDIO_AVAILABLE set to False")
-
-
-logger = logging.getLogger(__name__)
+    logger.warning("PresidioDetector import: FAILED (%s) — Presidio detection disabled", e)
 
 
 class CompositePIIDetector:

--- a/pii-detector-service/pii_detector/infrastructure/detector/presidio_detector.py
+++ b/pii-detector-service/pii_detector/infrastructure/detector/presidio_detector.py
@@ -164,7 +164,7 @@ class PresidioDetector:
         detection_config = self.config.get("detection", {})
         self._default_threshold = detection_config.get("default_threshold", 0.5)
         self._languages = detection_config.get("languages", ["en"])
-        print("\n Languages", self._languages)
+        self.logger.info("Configured languages: %s", self._languages)
         self._labels_to_ignore = detection_config.get("labels_to_ignore", [
             "CARDINAL", "MONEY", "WORK_OF_ART", "PRODUCT", "ORDINAL",
             "QUANTITY", "PERCENT", "LANGUAGE", "EVENT", "LAW", "FAC"

--- a/pii-detector-service/pii_detector/infrastructure/text_processing/semantic_chunker.py
+++ b/pii-detector-service/pii_detector/infrastructure/text_processing/semantic_chunker.py
@@ -133,11 +133,11 @@ class SemanticTextChunker:
                 # Move position forward for next search
                 current_pos = end
             
-            self.logger.debug(
-                f"Chunked {len(text)} chars into {len(results)} semantic chunks"
-            )
             elapsed_time = time.time() - start_time
-            print(f"[chunk_text] Chunking text completed in {elapsed_time:.2f}s")
+            self.logger.debug(
+                f"Chunked {len(text)} chars into {len(results)} semantic chunks "
+                f"in {elapsed_time:.2f}s"
+            )
             return results
             
         except Exception as e:


### PR DESCRIPTION
## Summary
Remove five stray debug `print()` statements that were reaching stdout at runtime, replacing them with properly-scoped `logger` calls.

## Category
- [ ] Algorithmic optimization
- [ ] Missing tests
- [ ] Refactoring
- [ ] Documentation
- [ ] SonarQube issue fix
- [x] Chore / logging hygiene

## Files changed
- `pii-detector-service/pii_detector/infrastructure/text_processing/semantic_chunker.py` — drop the per-chunk timing print; merge the timing into the existing debug log
- `pii-detector-service/pii_detector/application/orchestration/composite_detector.py` — move `logger = logging.getLogger(...)` above the optional Presidio import, replace the 3 import-time prints with one info + one warning log
- `pii-detector-service/pii_detector/infrastructure/detector/presidio_detector.py` — replace the `"\n Languages"` print with `self.logger.info`

## Verification
- [x] Python syntax OK (`python -m py_compile` on all 3 files)
- [x] No test references these prints or the exact log messages — behavioural change is log-channel only
- [x] Max 5 files modified (3 files)
- [x] No protected files modified

## Details

### Why it matters
`print()` bypasses the configured logging pipeline: level filtering, handlers, formatters, correlation ids, and async queue listener (the one set up in `pii_service.py` for PII audit logs). It also flushes stdout synchronously.

The worst offender is in the detection hot path:

```python
# semantic_chunker.py — on every DetectPII request:
print(f"[chunk_text] Chunking text completed in {elapsed_time:.2f}s")
```

At thousands of chunks per scan, that is thousands of synchronous stdout writes per gRPC request.

### Mapping

| Before | After |
|--------|-------|
| `print(f"[chunk_text] Chunking text completed in {...}s")` (hot path) | Merged into existing `logger.debug` chunk log |
| `print("[PRESIDIO_IMPORT] SUCCESS ...")` (import) | `logger.info("PresidioDetector import: SUCCESS")` |
| `print(f"[PRESIDIO_IMPORT] FAILED - ImportError: {e}")` + `print("... PRESIDIO_AVAILABLE set to False")` | One `logger.warning("PresidioDetector import: FAILED (%s) — Presidio detection disabled", e)` |
| `print("\n Languages", self._languages)` (init) | `self.logger.info("Configured languages: %s", self._languages)` |

---
*Generated by Claude Code — autonomous continuous improvement*