### PR TITLE
perf(reporting): index SpaceCounters by (scanId, spaceKey) for O(1) lookup

### DIFF
--- a/pii-reporting-api/src/main/java/pro/softcom/aisentinel/application/pii/reporting/usecase/ScanReportingUseCase.java
+++ b/pii-reporting-api/src/main/java/pro/softcom/aisentinel/application/pii/reporting/usecase/ScanReportingUseCase.java
@@ -161,31 +161,27 @@ public class ScanReportingUseCase implements ScanReportingPort {
                 scanIds.add(cp.scanId());
             }
 
-            // 3) Load counters for these scanIds
-            Map<String, List<ScanResultQuery.SpaceCounter>> countersByScan = new HashMap<>();
+            // 3) Load counters for these scanIds, indexed scanId -> spaceKey -> counter
+            //    so step 4 can fetch the counter for a (scanId, spaceKey) pair in O(1)
+            //    instead of scanning the per-scan list for each checkpoint.
+            Map<String, Map<String, ScanResultQuery.SpaceCounter>> countersByScan = new HashMap<>();
             for (String scanId : scanIds) {
-                countersByScan.put(scanId, scanResultQuery.getSpaceCounters(scanId));
+                Map<String, ScanResultQuery.SpaceCounter> bySpace = new HashMap<>();
+                for (ScanResultQuery.SpaceCounter sc : scanResultQuery.getSpaceCounters(scanId)) {
+                    bySpace.put(sc.spaceKey(), sc);
+                }
+                countersByScan.put(scanId, bySpace);
             }
 
             // 4) Build space summaries
             List<SpaceSummary> spaces = new ArrayList<>();
             for (ScanCheckpoint cp : latestCheckpoints) {
-                List<ScanResultQuery.SpaceCounter> scanCounters = countersByScan.get(cp.scanId());
+                Map<String, ScanResultQuery.SpaceCounter> bySpace = countersByScan.get(cp.scanId());
+                ScanResultQuery.SpaceCounter sc = bySpace != null ? bySpace.get(cp.spaceKey()) : null;
 
-                long pagesDone = 0;
-                long attachmentsDone = 0;
-                Instant lastEventTs = null;
-
-                if (scanCounters != null) {
-                    for (ScanResultQuery.SpaceCounter sc : scanCounters) {
-                        if (sc.spaceKey().equals(cp.spaceKey())) {
-                            pagesDone = sc.pagesDone();
-                            attachmentsDone = sc.attachmentsDone();
-                            lastEventTs = sc.lastEventTs();
-                            break;
-                        }
-                    }
-                }
+                long pagesDone = sc != null ? sc.pagesDone() : 0;
+                long attachmentsDone = sc != null ? sc.attachmentsDone() : 0;
+                Instant lastEventTs = sc != null ? sc.lastEventTs() : null;
 
                 spaces.add(new SpaceSummary(
                     cp.spaceKey(),


### PR DESCRIPTION
## Summary
- `getGlobalScanSummary` built `countersByScan` as `Map<scanId, List<SpaceCounter>>`, then scanned the list linearly for every checkpoint to find the one matching the checkpoint's `spaceKey`.
- With N checkpoints across M counters per scan, this is **O(N × M)** on every call of the global-summary endpoint (dashboard polling).
- Reindexed `countersByScan` as `Map<scanId, Map<spaceKey, SpaceCounter>>` at build time → the per-checkpoint lookup becomes a single `Map.get`.

## Category
- [x] Algorithmic optimization
- [ ] Refactoring
- [ ] Missing tests
- [ ] Documentation
- [ ] SonarQube issue fix

## Files changed
- `application/pii/reporting/usecase/ScanReportingUseCase.java` — reindex `countersByScan`, collapse the inner loop into a direct `Map.get`, tighten the null handling around `pagesDone` / `attachmentsDone` / `lastEventTs`

## Complexity

| Measure                          | Before        | After            |
|----------------------------------|---------------|------------------|
| Build index                      | O(Σ M_i)      | O(Σ M_i)         |
| Per-checkpoint counter lookup    | O(M)          | O(1)             |
| Total step 3+4                   | O(N × M)      | O(N + Σ M_i)     |

N = number of checkpoints (one per scanned space), M = counters per scan. Typical ranges are small (dozens), but the quadratic shows up on every dashboard refresh and the scan grows with Confluence tenancy — the optimization removes accidental quadratic behavior on a user-visible polling path.

## Verification
- [x] `ScanReportingUseCaseTest` passes (5 tests including the global-summary path with mixed-space checkpoints)
- [x] Build succeeds
- [x] No functional change — null handling preserved, defaults (0 / 0 / null) applied when no counter matches the checkpoint's spaceKey
- [x] Max 5 files modified (1 changed, 34 lines touched)
- [x] No protected files modified

## Details
Secondary refactor: the three "counter → summary field" assignments were guarded by an `if (scanCounters != null)` block with an early-break inner loop. With the indexed map they collapse to three ternaries (`sc != null ? sc.field() : default`). Same semantics, less nesting — identical defaults as before when there is no matching counter.

---
*Generated by Claude Code — autonomous continuous improvement*