### PR TITLE
fix(confluence): build proper Cloud deep-links for pages and attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ https://github.com/user-attachments/assets/d2c633d6-3209-4b2f-b80a-88fe2e41f945
 - ✅ **Modern Web interface**: Angular dashboard with real-time scan visualization
 - ✅ **Detailed reports**: Report generation with statistics and PII location
 - ✅ **Microservices architecture**: Python (gRPC), Java (Spring Boot), and Angular services
+- ✅ **Configurable detectors & PII types**: Enable/disable individual detectors (GLiNER, Presidio, Regex) and specific PII types (names, emails, IBANs…) from `Settings > PII Settings`
+- ✅ **Tunable confidence thresholds**: Global default threshold + per-type override to reduce false positives (`Settings > PII Settings > Thresholds` / `PII Types`)
+- ✅ **Zero-shot custom labels (GLiNER)**: Add your own entities to detect on-the-fly without retraining, leveraging `nvidia/gliner-PII` zero-shot capabilities (`Settings > PII Settings > PII Types > + Add custom label` on the GLINER group). ⚠️ **No reliability guarantee**: zero-shot detection quality depends heavily on the label wording and the underlying model — validate results on a representative sample before relying on them in production.
 - ✅ **Scan management**: Pause, resume, and real-time tracking of ongoing scans
 - ✅ **PostgreSQL database**: Persistent storage of results and history
 - 🚧 **Report export** (in progress): CSV/PDF export of scan results
@@ -364,7 +367,12 @@ docker image prune -a
 
 # Complete cleanup (warning: removes EVERYTHING)
 docker system prune -a --volumes
+
+# Full reinstallation (removes volumes + images + cache, forces re-pull and re-bootstrap)
+docker-compose down -v --rmi all && docker system prune -af && docker-compose pull && docker-compose up -d
 ```
+
+> ⚠️ After running the full reinstallation command, the Infisical bootstrap will re-run — you must repeat **Step 2** of the [Quick Setup](#quick-setup-2-steps) (`--force-recreate` of `pii-detector`, `pii-reporting-api`, and `pii-reporting-ui`).
 
 ### REST API Endpoints
 
@@ -563,6 +571,12 @@ Use [GitHub Issues](https://github.com/Softcom-Technologies-Organization/ai-sent
 
 **Q: What types of PII are detected?**  
 A: First names, last names, emails, phones, addresses, social security numbers, credit cards, dates of birth, and more.
+
+**Q: Can I disable specific PII types or adjust detection sensitivity?**  
+A: Yes, via `Settings > PII Settings`. You can toggle detectors (GLiNER, Presidio, Regex), enable/disable individual PII types, and adjust the global confidence threshold as well as per-type thresholds.
+
+**Q: Can I detect custom entities not in the default PII list?**  
+A: Yes, through zero-shot custom labels on the GLiNER detector (`Settings > PII Settings > PII Types > + Add custom label`). ⚠️ Detection reliability is **not guaranteed** for zero-shot labels — results depend on the label wording and the underlying `nvidia/gliner-PII` model. Always validate on a representative sample before trusting the output.
 
 **Q: Do models work offline?**  
 A: Yes, after the first download, models are cached locally.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -557,7 +557,7 @@ services:
   # PII DETECTOR SERVICE (Python/gRPC) - PRE-BUILT IMAGE
   # ============================================================================
   pii-detector:
-    image: ghcr.io/softcom-technologies-organization/ai-sentinel-pii-detector:v1.1.0-rc.1
+    image: ghcr.io/softcom-technologies-organization/ai-sentinel-pii-detector:v1.1.1-rc.1
     container_name: pii-detector-service
     restart: unless-stopped
     
@@ -612,7 +612,7 @@ services:
   # PII REPORTING API (Spring Boot) - PRE-BUILT IMAGE
   # ============================================================================
   pii-reporting-api:
-    image: ghcr.io/softcom-technologies-organization/ai-sentinel-reporting-api:v1.1.0-rc.1
+    image: ghcr.io/softcom-technologies-organization/ai-sentinel-reporting-api:v1.1.1-rc.1
     container_name: pii-reporting-api
     restart: unless-stopped
     ports:
@@ -661,7 +661,7 @@ services:
   # PII REPORTING UI (Angular + Nginx) - PRE-BUILT IMAGE
   # ============================================================================
   pii-reporting-ui:
-    image: ghcr.io/softcom-technologies-organization/ai-sentinel-reporting-ui:v1.1.0-rc.1
+    image: ghcr.io/softcom-technologies-organization/ai-sentinel-reporting-ui:v1.1.1-rc.1
     container_name: pii-reporting-ui
     restart: unless-stopped
     ports:

--- a/pii-detector-service/pyproject.toml
+++ b/pii-detector-service/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pii-detector"
-version = "1.1.0.dev0"
+version = "1.1.1.dev0"
 description = "PII Detection gRPC Microservice using Piiranha model with advanced memory management"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pii-reporting-api/pom.xml
+++ b/pii-reporting-api/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>pro.softcom</groupId>
     <artifactId>ai-sentinel</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <name>ai-sentinel</name>
     <description>ai-sentinel - Application to scan Confluence spaces and reporting PIIs</description>
 

--- a/pii-reporting-api/src/main/java/pro/softcom/aisentinel/application/confluence/port/out/ConfluenceUrlProvider.java
+++ b/pii-reporting-api/src/main/java/pro/softcom/aisentinel/application/confluence/port/out/ConfluenceUrlProvider.java
@@ -6,9 +6,39 @@ package pro.softcom.aisentinel.application.confluence.port.out;
  */
 public interface ConfluenceUrlProvider {
     String baseUrl();
+
     /**
      * Build a public page URL for the given Confluence page identifier.
-     * Returns null when pageId or baseUrl is blank.
+     *
+     * <p>The {@code spaceKey} is required for Confluence Cloud deployments, whose canonical
+     * page URL format is {@code {base}/spaces/{spaceKey}/pages/{pageId}}. Data Center
+     * deployments rely on the legacy {@code {base}/pages/viewpage.action?pageId={pageId}}
+     * format, where the space key is not needed and is therefore ignored.
+     *
+     * @param spaceKey Confluence space key (mandatory for Cloud, ignored for Data Center)
+     * @param pageId   Confluence page identifier
+     * @return the public page URL, or {@code null} when a required input is blank
+     *         (baseUrl, pageId, or spaceKey for Cloud deployments)
      */
-    String pageUrl(String pageId);
+    String pageUrl(String spaceKey, String pageId);
+
+    /**
+     * Build a URL that lists attachments visible from a user-friendly navigation context.
+     *
+     * <p>Cloud and Data Center expose attachments at different granularities:
+     * <ul>
+     *     <li>Cloud: {@code {base}/spaces/listattachmentsforspace.action?key={spaceKey}} —
+     *     space-level listing; the space key is URL-encoded and the page id is ignored.</li>
+     *     <li>Data Center: {@code {base}/pages/viewpageattachments.action?pageId={pageId}} —
+     *     page-level listing; the space key is ignored.</li>
+     * </ul>
+     *
+     * <p>This asymmetry reflects a deliberate product choice and is not normalized.
+     *
+     * @param spaceKey Confluence space key (mandatory for Cloud, ignored for Data Center)
+     * @param pageId   Confluence page identifier (mandatory for Data Center, ignored for Cloud)
+     * @return the attachments listing URL, or {@code null} when a required input is blank
+     *         (baseUrl, spaceKey for Cloud, or pageId for Data Center)
+     */
+    String attachmentsUrl(String spaceKey, String pageId);
 }

--- a/pii-reporting-api/src/main/java/pro/softcom/aisentinel/application/pii/reporting/service/ScanEventFactory.java
+++ b/pii-reporting-api/src/main/java/pro/softcom/aisentinel/application/pii/reporting/service/ScanEventFactory.java
@@ -78,7 +78,7 @@ public class ScanEventFactory {
             .pageIndex(pageIndex)
             .pageId(page.id())
             .pageTitle(page.title())
-            .pageUrl(buildPageUrl(page.id()))
+            .pageUrl(buildPageUrl(spaceKey, page.id()))
             .emittedAt(Instant.now().toString())
             .analysisProgressPercentage(progress)
             .scanStatus(ScanStatus.RUNNING)
@@ -96,7 +96,7 @@ public class ScanEventFactory {
             .eventType(DetectionReportingEventType.PAGE_COMPLETE.getLabel())
             .pageId(page.id())
             .pageTitle(page.title())
-            .pageUrl(buildPageUrl(page.id()))
+            .pageUrl(buildPageUrl(spaceKey, page.id()))
             .emittedAt(Instant.now().toString())
             .analysisProgressPercentage(progress)
             .scanStatus(ScanStatus.RUNNING)
@@ -119,7 +119,7 @@ public class ScanEventFactory {
             .detectedPIIList(List.of())
             .nbOfDetectedPIIBySeverity(Map.of())
             .nbOfDetectedPIIByType(Map.of())
-            .pageUrl(buildPageUrl(page.id()))
+            .pageUrl(buildPageUrl(spaceKey, page.id()))
             .emittedAt(Instant.now().toString())
             .analysisProgressPercentage(progress)
             .scanStatus(ScanStatus.RUNNING)
@@ -150,7 +150,7 @@ public class ScanEventFactory {
             .nbOfDetectedPIIBySeverity(summary)
             .nbOfDetectedPIIByType(piiTypeSummary)
             .sourceContent(content)
-            .pageUrl(buildPageUrl(page.id()))
+            .pageUrl(buildPageUrl(spaceKey, page.id()))
             .emittedAt(Instant.now().toString())
             .analysisProgressPercentage(progress)
             .scanStatus(ScanStatus.RUNNING)
@@ -181,7 +181,7 @@ public class ScanEventFactory {
             .nbOfDetectedPIIBySeverity(summary)
             .nbOfDetectedPIIByType(piiTypeSummary)
             .sourceContent(content)
-            .pageUrl(buildPageUrl(page.id()))
+            .pageUrl(buildAttachmentsUrl(spaceKey, page.id()))
             .attachmentName(attachment.name())
             .attachmentType(attachment.mimeType())
             .attachmentUrl(attachment.url())
@@ -203,7 +203,7 @@ public class ScanEventFactory {
             .eventType(DetectionReportingEventType.ERROR.getLabel())
             .pageId(pageId)
             .message(errorMessage)
-            .pageUrl(buildPageUrl(pageId))
+            .pageUrl(buildPageUrl(spaceKey, pageId))
             .emittedAt(Instant.now().toString())
             .analysisProgressPercentage(progress)
             .scanStatus(ScanStatus.FAILED)
@@ -375,10 +375,11 @@ public class ScanEventFactory {
         }
     }
 
-    private String buildPageUrl(String pageId) {
-        if (confluenceUrlProvider == null || pageId == null) {
-            return null;
-        }
-        return confluenceUrlProvider.pageUrl(pageId);
+    private String buildPageUrl(String spaceKey, String pageId) {
+        return confluenceUrlProvider.pageUrl(spaceKey, pageId);
+    }
+
+    private String buildAttachmentsUrl(String spaceKey, String pageId) {
+        return confluenceUrlProvider.attachmentsUrl(spaceKey, pageId);
     }
 }

--- a/pii-reporting-api/src/main/java/pro/softcom/aisentinel/infrastructure/confluence/adapter/out/ConfluenceUrlProviderAdapter.java
+++ b/pii-reporting-api/src/main/java/pro/softcom/aisentinel/infrastructure/confluence/adapter/out/ConfluenceUrlProviderAdapter.java
@@ -1,5 +1,8 @@
 package pro.softcom.aisentinel.infrastructure.confluence.adapter.out;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import pro.softcom.aisentinel.application.confluence.port.out.ConfluenceUrlProvider;
@@ -25,21 +28,55 @@ public class ConfluenceUrlProviderAdapter implements ConfluenceUrlProvider {
     }
 
     @Override
-    public String pageUrl(String pageId) {
-        if (pageId == null || pageId.isBlank()) {
+    public String pageUrl(String spaceKey, String pageId) {
+        if (isBlank(pageId)) {
             return null;
         }
+        String normalizedBase = normalizedBaseUrl();
+        if (normalizedBase == null) {
+            return null;
+        }
+        if (confluenceConnectionConfig.deploymentType() == ConfluenceDeploymentType.DATA_CENTER) {
+            return normalizedBase + "/pages/viewpage.action?pageId=" + pageId;
+        }
+        if (isBlank(spaceKey)) {
+            return null;
+        }
+        return normalizedBase + "/spaces/" + urlEncode(spaceKey) + "/pages/" + pageId;
+    }
+
+    @Override
+    public String attachmentsUrl(String spaceKey, String pageId) {
+        String normalizedBase = normalizedBaseUrl();
+        if (normalizedBase == null) {
+            return null;
+        }
+        if (confluenceConnectionConfig.deploymentType() == ConfluenceDeploymentType.DATA_CENTER) {
+            if (isBlank(pageId)) {
+                return null;
+            }
+            return normalizedBase + "/pages/viewpageattachments.action?pageId=" + pageId;
+        }
+        if (isBlank(spaceKey)) {
+            return null;
+        }
+        return normalizedBase + "/spaces/listattachmentsforspace.action?key=" + urlEncode(spaceKey);
+    }
+
+    private String normalizedBaseUrl() {
         String base = baseUrl();
-        if (base == null || base.isBlank()) {
+        if (isBlank(base)) {
             return null;
         }
         base = base.trim();
-        if (base.endsWith("/")) {
-            base = base.substring(0, base.length() - 1);
-        }
-        if (confluenceConnectionConfig.deploymentType() == ConfluenceDeploymentType.DATA_CENTER) {
-            return base + "/pages/viewpage.action?pageId=" + pageId;
-        }
-        return base + "/pages/" + pageId;
+        return base.endsWith("/") ? base.substring(0, base.length() - 1) : base;
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private static String urlEncode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
     }
 }

--- a/pii-reporting-api/src/test/java/pro/softcom/aisentinel/application/pii/reporting/service/ScanEventFactoryTest.java
+++ b/pii-reporting-api/src/test/java/pro/softcom/aisentinel/application/pii/reporting/service/ScanEventFactoryTest.java
@@ -1,0 +1,169 @@
+package pro.softcom.aisentinel.application.pii.reporting.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import pro.softcom.aisentinel.application.confluence.port.out.ConfluenceUrlProvider;
+import pro.softcom.aisentinel.application.pii.reporting.SeverityCalculationService;
+import pro.softcom.aisentinel.application.pii.reporting.usecase.DetectionReportingEventType;
+import pro.softcom.aisentinel.domain.confluence.AttachmentInfo;
+import pro.softcom.aisentinel.domain.confluence.ConfluencePage;
+import pro.softcom.aisentinel.domain.pii.reporting.ConfluenceContentScanResult;
+import pro.softcom.aisentinel.domain.pii.scan.ContentPiiDetection;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link ScanEventFactory} focused on URL routing between events.
+ *
+ * <p>Business intent: guarantee that each event type uses the <em>correct</em> URL port method.
+ * In particular, {@code ATTACHMENT_ITEM} must use {@code attachmentsUrl} (listing URL)
+ * while all page-level events must use {@code pageUrl} (canonical page URL).
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ScanEventFactory - URL routing per event type")
+class ScanEventFactoryTest {
+
+    private static final String SCAN_ID = "scan-1";
+    private static final String SPACE_KEY = "TEAM";
+    private static final String PAGE_ID = "page-42";
+    private static final String PAGE_TITLE = "My Page";
+
+    private static final String PAGE_URL = "https://example.atlassian.net/wiki/spaces/TEAM/pages/page-42";
+    private static final String ATTACHMENTS_URL = "https://example.atlassian.net/wiki/spaces/listattachmentsforspace.action?key=TEAM";
+
+    @Mock
+    private ConfluenceUrlProvider confluenceUrlProvider;
+
+    @Mock
+    private PiiContextExtractor piiContextExtractor;
+
+    @Mock
+    private SeverityCalculationService severityCalculationService;
+
+    private ScanEventFactory scanEventFactory;
+
+    @BeforeEach
+    void setUp() {
+        scanEventFactory = new ScanEventFactory(confluenceUrlProvider, piiContextExtractor, severityCalculationService);
+    }
+
+    @Test
+    @DisplayName("ATTACHMENT_ITEM event uses attachmentsUrl(spaceKey, pageId) and NOT pageUrl")
+    void Should_UseAttachmentsUrl_When_EventTypeIsAttachmentItem() {
+        ConfluencePage page = aPage();
+        AttachmentInfo attachment = new AttachmentInfo("file.pdf", "pdf", "application/pdf", "https://files/file.pdf");
+        ContentPiiDetection detection = emptyDetection();
+        when(confluenceUrlProvider.attachmentsUrl(SPACE_KEY, PAGE_ID)).thenReturn(ATTACHMENTS_URL);
+
+        ConfluenceContentScanResult event = scanEventFactory.createAttachmentItemEvent(
+            SCAN_ID, SPACE_KEY, page, attachment, "content", detection, 10.0);
+
+        assertThat(event.eventType()).isEqualTo(DetectionReportingEventType.ATTACHMENT_ITEM.getLabel());
+        assertThat(event.pageUrl())
+            .as("pageUrl on ATTACHMENT_ITEM must be the attachments listing URL")
+            .isEqualTo(ATTACHMENTS_URL);
+        verify(confluenceUrlProvider).attachmentsUrl(SPACE_KEY, PAGE_ID);
+        verifyNoMoreInteractions(confluenceUrlProvider);
+    }
+
+    @Test
+    @DisplayName("PAGE_START event uses pageUrl(spaceKey, pageId)")
+    void Should_UsePageUrl_When_EventTypeIsPageStart() {
+        ConfluencePage page = aPage();
+        when(confluenceUrlProvider.pageUrl(SPACE_KEY, PAGE_ID)).thenReturn(PAGE_URL);
+
+        ConfluenceContentScanResult event = scanEventFactory.createPageStartEvent(
+            SCAN_ID, SPACE_KEY, page, 0, 1, 5.0);
+
+        assertThat(event.eventType()).isEqualTo(DetectionReportingEventType.PAGE_START.getLabel());
+        assertThat(event.pageUrl()).isEqualTo(PAGE_URL);
+        verify(confluenceUrlProvider).pageUrl(SPACE_KEY, PAGE_ID);
+        verifyNoMoreInteractions(confluenceUrlProvider);
+    }
+
+    @Test
+    @DisplayName("PAGE_COMPLETE event uses pageUrl(spaceKey, pageId)")
+    void Should_UsePageUrl_When_EventTypeIsPageComplete() {
+        ConfluencePage page = aPage();
+        when(confluenceUrlProvider.pageUrl(SPACE_KEY, PAGE_ID)).thenReturn(PAGE_URL);
+
+        ConfluenceContentScanResult event = scanEventFactory.createPageCompleteEvent(
+            SCAN_ID, SPACE_KEY, page, 100.0);
+
+        assertThat(event.eventType()).isEqualTo(DetectionReportingEventType.PAGE_COMPLETE.getLabel());
+        assertThat(event.pageUrl()).isEqualTo(PAGE_URL);
+        verify(confluenceUrlProvider).pageUrl(SPACE_KEY, PAGE_ID);
+        verifyNoMoreInteractions(confluenceUrlProvider);
+    }
+
+    @Test
+    @DisplayName("Empty ITEM event uses pageUrl(spaceKey, pageId)")
+    void Should_UsePageUrl_When_EventTypeIsEmptyItem() {
+        ConfluencePage page = aPage();
+        when(confluenceUrlProvider.pageUrl(SPACE_KEY, PAGE_ID)).thenReturn(PAGE_URL);
+
+        ConfluenceContentScanResult event = scanEventFactory.createEmptyPageItemEvent(
+            SCAN_ID, SPACE_KEY, page, 50.0);
+
+        assertThat(event.eventType()).isEqualTo(DetectionReportingEventType.ITEM.getLabel());
+        assertThat(event.pageUrl()).isEqualTo(PAGE_URL);
+        verify(confluenceUrlProvider).pageUrl(SPACE_KEY, PAGE_ID);
+        verifyNoMoreInteractions(confluenceUrlProvider);
+    }
+
+    @Test
+    @DisplayName("Non-empty ITEM event uses pageUrl(spaceKey, pageId) and NOT attachmentsUrl")
+    void Should_UsePageUrl_When_EventTypeIsPageItem() {
+        ConfluencePage page = aPage();
+        ContentPiiDetection detection = emptyDetection();
+        when(confluenceUrlProvider.pageUrl(SPACE_KEY, PAGE_ID)).thenReturn(PAGE_URL);
+
+        ConfluenceContentScanResult event = scanEventFactory.createPageItemEvent(
+            SCAN_ID, SPACE_KEY, page, "content", detection, 80.0);
+
+        assertThat(event.eventType()).isEqualTo(DetectionReportingEventType.ITEM.getLabel());
+        assertThat(event.pageUrl()).isEqualTo(PAGE_URL);
+        verify(confluenceUrlProvider).pageUrl(SPACE_KEY, PAGE_ID);
+        verifyNoMoreInteractions(confluenceUrlProvider);
+    }
+
+    @Test
+    @DisplayName("ERROR event uses pageUrl(spaceKey, pageId)")
+    void Should_UsePageUrl_When_EventTypeIsError() {
+        when(confluenceUrlProvider.pageUrl(SPACE_KEY, PAGE_ID)).thenReturn(PAGE_URL);
+
+        ConfluenceContentScanResult event = scanEventFactory.createErrorEvent(
+            SCAN_ID, SPACE_KEY, PAGE_ID, "boom", 75.0);
+
+        assertThat(event.eventType()).isEqualTo(DetectionReportingEventType.ERROR.getLabel());
+        assertThat(event.pageUrl()).isEqualTo(PAGE_URL);
+        verify(confluenceUrlProvider).pageUrl(SPACE_KEY, PAGE_ID);
+        verifyNoMoreInteractions(confluenceUrlProvider);
+    }
+
+    private static ConfluencePage aPage() {
+        return ConfluencePage.builder()
+            .id(PAGE_ID)
+            .title(PAGE_TITLE)
+            .spaceKey(SPACE_KEY)
+            .content(new ConfluencePage.HtmlContent("body"))
+            .build();
+    }
+
+    private static ContentPiiDetection emptyDetection() {
+        return ContentPiiDetection.builder()
+            .sensitiveDataFound(List.of())
+            .statistics(Map.of())
+            .build();
+    }
+}

--- a/pii-reporting-api/src/test/java/pro/softcom/aisentinel/application/pii/reporting/usecase/StreamConfluenceResumeScanUseCaseTest.java
+++ b/pii-reporting-api/src/test/java/pro/softcom/aisentinel/application/pii/reporting/usecase/StreamConfluenceResumeScanUseCaseTest.java
@@ -85,17 +85,7 @@ class StreamConfluenceResumeScanUseCaseTest {
 
     @BeforeEach
     void setUp() {
-        final ConfluenceUrlProvider confluenceUrlProvider = new ConfluenceUrlProvider() {
-            @Override public String baseUrl() { return "http://confluence.example"; }
-            @Override public String pageUrl(String pageId) {
-                if (pageId == null || pageId.isBlank()) return null;
-                String base = baseUrl();
-                if (base.isBlank()) return null;
-                base = base.trim();
-                if (base.endsWith("/")) base = base.substring(0, base.length() - 1);
-                return base + "/pages/viewpage.action?pageId=" + pageId;
-            }
-        };
+        final ConfluenceUrlProvider confluenceUrlProvider = stubDataCenterUrlProvider();
         
         // Create service instances
         var applicationEventPublisher = Mockito.mock(ApplicationEventPublisher.class);
@@ -163,7 +153,7 @@ class StreamConfluenceResumeScanUseCaseTest {
             .timeout(Duration.ofSeconds(5));
 
         StepVerifier.create(flux)
-            .assertNext(ev -> assertThat(ev.analysisProgressPercentage()).isEqualTo(0.0))
+            .assertNext(ev -> assertThat(ev.analysisProgressPercentage()).isZero())
             .verifyComplete();
     }
 
@@ -263,5 +253,30 @@ class StreamConfluenceResumeScanUseCaseTest {
             .expectNextMatches(ev -> "pA".equals(ev.pageId()))
             .expectNextMatches(ev -> "pB".equals(ev.pageId()))
             .verifyComplete();
+    }
+
+    /**
+     * Builds a Mockito stub of {@link ConfluenceUrlProvider} that mimics the Data Center
+     * adapter output, so test assertions can rely on a stable canonical URL shape.
+     */
+    private static ConfluenceUrlProvider stubDataCenterUrlProvider() {
+        String normalizedBase = normalizeBaseUrl();
+        ConfluenceUrlProvider provider = Mockito.mock(ConfluenceUrlProvider.class);
+        Mockito.lenient().when(provider.baseUrl()).thenReturn("http://confluence.example");
+        Mockito.lenient().when(provider.pageUrl(any(), any())).thenAnswer(invocation -> {
+            String pageId = invocation.getArgument(1);
+            if (pageId == null || pageId.isBlank()) return null;
+            return normalizedBase + "/pages/viewpage.action?pageId=" + pageId;
+        });
+        Mockito.lenient().when(provider.attachmentsUrl(any(), any())).thenAnswer(invocation -> {
+            String pageId = invocation.getArgument(1);
+            if (pageId == null || pageId.isBlank()) return null;
+            return normalizedBase + "/pages/viewpageattachments.action?pageId=" + pageId;
+        });
+        return provider;
+    }
+
+    private static String normalizeBaseUrl() {
+        return "http://confluence.example".trim();
     }
 }

--- a/pii-reporting-api/src/test/java/pro/softcom/aisentinel/application/pii/reporting/usecase/StreamConfluenceScanUseCaseTest.java
+++ b/pii-reporting-api/src/test/java/pro/softcom/aisentinel/application/pii/reporting/usecase/StreamConfluenceScanUseCaseTest.java
@@ -92,20 +92,7 @@ class StreamConfluenceScanUseCaseTest {
 
     @BeforeEach
     void setUp() {
-        // Keep only baseUrl relevant for URL building
-        final ConfluenceUrlProvider confluenceUrlProvider = new ConfluenceUrlProvider() {
-            @Override public String baseUrl() { return "http://confluence.example"; }
-            @Override public String pageUrl(String pageId) {
-                if (pageId == null || pageId.isBlank()) return null;
-                String base = baseUrl();
-                if (base.isBlank()) {
-                    return null;
-                }
-                base = base.trim();
-                if (base.endsWith("/")) base = base.substring(0, base.length() - 1);
-                return base + "/pages/viewpage.action?pageId=" + pageId;
-            }
-        };
+        final ConfluenceUrlProvider confluenceUrlProvider = stubDataCenterUrlProvider("http://confluence.example");
 
         // Create service instances
         var applicationEventPublisher = Mockito.mock(ApplicationEventPublisher.class);
@@ -557,20 +544,9 @@ class StreamConfluenceScanUseCaseTest {
     @Test
     @DisplayName("buildPageUrl - null when baseUrl is blank")
     void Should_UseNullPageUrl_When_BaseUrlIsBlank() {
-        // Build a dedicated service with blank base URL
-        final ConfluenceUrlProvider blankUrlProvider = new ConfluenceUrlProvider() {
-            @Override public String baseUrl() { return "   "; }
-            @Override public String pageUrl(String pageId) {
-                String base = baseUrl();
-                if (base.isBlank()) {
-                    return null;
-                }
-                if (pageId == null || pageId.isBlank()) return null;
-                base = base.trim();
-                if (base.endsWith("/")) base = base.substring(0, base.length() - 1);
-                return base + "/pages/viewpage.action?pageId=" + pageId;
-            }
-        };
+        // Blank base URL -> provider returns null for every URL (mimics adapter behavior).
+        final ConfluenceUrlProvider blankUrlProvider = Mockito.mock(ConfluenceUrlProvider.class);
+        Mockito.lenient().when(blankUrlProvider.baseUrl()).thenReturn("   ");
 
         // Create service instances
         var applicationEventPublisher = Mockito.mock(ApplicationEventPublisher.class);
@@ -634,20 +610,8 @@ class StreamConfluenceScanUseCaseTest {
     @Test
     @DisplayName("buildPageUrl - trims trailing slash in baseUrl (dedicated provider)")
     void Should_BuildPageUrlWithoutDoubleSlash_When_ProviderEndsWithSlash() {
-        // Build a dedicated service with trailing slash
-        final ConfluenceUrlProvider confluenceUrlProvider = new ConfluenceUrlProvider() {
-            @Override public String baseUrl() { return "http://confluence.example/"; }
-            @Override public String pageUrl(String pageId) {
-                if (pageId == null || pageId.isBlank()) return null;
-                String base = baseUrl();
-                if (base.isBlank()) {
-                    return null;
-                }
-                base = base.trim();
-                if (base.endsWith("/")) base = base.substring(0, base.length() - 1);
-                return base + "/pages/viewpage.action?pageId=" + pageId;
-            }
-        };
+        // Trailing slash is normalized by the helper so the stubbed URL has no double slash.
+        final ConfluenceUrlProvider confluenceUrlProvider = stubDataCenterUrlProvider("http://confluence.example/");
 
         // Create service instances
         var applicationEventPublisher = Mockito.mock(ApplicationEventPublisher.class);
@@ -810,10 +774,10 @@ class StreamConfluenceScanUseCaseTest {
             .assertNext(ev -> {
                 assertThat(ev.eventType()).isEqualTo(ScanEventType.ERROR.toJson());
                 assertThat(ev.spaceKey()).isEqualTo("CCAEI");
-                assertThat(ev.message()).isNotNull();
-                assertThat(ev.message()).isNotEmpty();
-                assertThat(ev.message()).doesNotContain("null");
-                assertThat(ev.message()).containsIgnoringCase("connect");
+                assertThat(ev.message())
+                        .isNotEmpty()
+                        .doesNotContain("null")
+                        .containsIgnoringCase("connect");
             })
             .expectNextMatches(ev -> ScanEventType.MULTI_COMPLETE.toJson().equals(ev.eventType()))
             .verifyComplete();
@@ -837,10 +801,10 @@ class StreamConfluenceScanUseCaseTest {
             .assertNext(ev -> {
                 assertThat(ev.eventType()).isEqualTo(ScanEventType.ERROR.toJson());
                 assertThat(ev.spaceKey()).isEqualTo(spaceKey);
-                assertThat(ev.message()).isNotNull();
-                assertThat(ev.message()).isNotEmpty();
-                assertThat(ev.message()).doesNotContain("null");
-                assertThat(ev.message()).containsIgnoringCase("connect");
+                assertThat(ev.message())
+                        .isNotEmpty()
+                        .doesNotContain("null")
+                        .containsIgnoringCase("connect");
             })
             .verifyComplete();
     }
@@ -889,6 +853,34 @@ class StreamConfluenceScanUseCaseTest {
         // Verify both spaces were scanned
         verify(confluenceService, atLeastOnce()).getAllPagesInSpace("AHVIV");
         verify(confluenceService, atLeastOnce()).getAllPagesInSpace("XYZ");
+    }
+
+    /**
+     * Builds a Mockito stub of {@link ConfluenceUrlProvider} that mimics the Data Center
+     * adapter output. The base URL is normalized (trimmed + trailing slash removed) so the
+     * assertions in this file can compare against a clean canonical shape.
+     */
+    private static ConfluenceUrlProvider stubDataCenterUrlProvider(String rawBaseUrl) {
+        String normalizedBase = normalizeBaseUrl(rawBaseUrl);
+        ConfluenceUrlProvider provider = Mockito.mock(ConfluenceUrlProvider.class);
+        Mockito.lenient().when(provider.baseUrl()).thenReturn(rawBaseUrl);
+        Mockito.lenient().when(provider.pageUrl(any(), any())).thenAnswer(invocation -> {
+            String pageId = invocation.getArgument(1);
+            if (pageId == null || pageId.isBlank() || normalizedBase == null) return null;
+            return normalizedBase + "/pages/viewpage.action?pageId=" + pageId;
+        });
+        Mockito.lenient().when(provider.attachmentsUrl(any(), any())).thenAnswer(invocation -> {
+            String pageId = invocation.getArgument(1);
+            if (pageId == null || pageId.isBlank() || normalizedBase == null) return null;
+            return normalizedBase + "/pages/viewpageattachments.action?pageId=" + pageId;
+        });
+        return provider;
+    }
+
+    private static String normalizeBaseUrl(String rawBaseUrl) {
+        if (rawBaseUrl == null || rawBaseUrl.isBlank()) return null;
+        String trimmed = rawBaseUrl.trim();
+        return trimmed.endsWith("/") ? trimmed.substring(0, trimmed.length() - 1) : trimmed;
     }
 
 }

--- a/pii-reporting-api/src/test/java/pro/softcom/aisentinel/infrastructure/confluence/adapter/out/ConfluenceUrlProviderAdapterTest.java
+++ b/pii-reporting-api/src/test/java/pro/softcom/aisentinel/infrastructure/confluence/adapter/out/ConfluenceUrlProviderAdapterTest.java
@@ -1,0 +1,387 @@
+package pro.softcom.aisentinel.infrastructure.confluence.adapter.out;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import pro.softcom.aisentinel.domain.confluence.ConfluenceDeploymentType;
+import pro.softcom.aisentinel.infrastructure.confluence.adapter.out.config.ConfluenceConnectionConfig;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link ConfluenceUrlProviderAdapter}.
+ *
+ * <p>Covers:
+ * <ul>
+ *     <li>Cloud deployment with standard and personal space keys (expects {@code /spaces/{spaceKey}/pages/{pageId}})</li>
+ *     <li>Data Center deployment (expects the legacy {@code /pages/viewpage.action?pageId=} format, preserved verbatim)</li>
+ *     <li>Graceful degradation on blank or null inputs</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+class ConfluenceUrlProviderAdapterTest {
+
+    private static final String CLOUD_BASE_URL = "https://softcomtechnologies.atlassian.net/wiki";
+    private static final String DC_BASE_URL = "https://confluence.example.com";
+    private static final String PAGE_ID = "3757932546";
+    private static final String STANDARD_SPACE_KEY = "TEAM";
+    private static final String PERSONAL_SPACE_KEY = "~712020ca89d83794544f019984a297a88b7d27";
+
+    @Mock
+    private ConfluenceConnectionConfig confluenceConnectionConfig;
+
+    private ConfluenceUrlProviderAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        adapter = new ConfluenceUrlProviderAdapter(confluenceConnectionConfig);
+    }
+
+    @Test
+    @DisplayName("baseUrl returns the configured base URL verbatim")
+    void Should_ReturnConfiguredBaseUrl_When_BaseUrlIsRequested() {
+        when(confluenceConnectionConfig.baseUrl()).thenReturn(CLOUD_BASE_URL);
+
+        assertThat(adapter.baseUrl()).isEqualTo(CLOUD_BASE_URL);
+    }
+
+    @Test
+    @DisplayName("Cloud deployment builds /spaces/{spaceKey}/pages/{pageId} with a standard space key")
+    void Should_BuildCloudUrlWithSpacesSegment_When_DeploymentIsCloudAndSpaceKeyIsStandard() {
+        when(confluenceConnectionConfig.baseUrl()).thenReturn(CLOUD_BASE_URL);
+        when(confluenceConnectionConfig.deploymentType()).thenReturn(ConfluenceDeploymentType.CLOUD);
+
+        String url = adapter.pageUrl(STANDARD_SPACE_KEY, PAGE_ID);
+
+        assertThat(url).isEqualTo(CLOUD_BASE_URL + "/spaces/" + STANDARD_SPACE_KEY + "/pages/" + PAGE_ID);
+    }
+
+    @Test
+    @DisplayName("Cloud deployment URL-encodes the space key when it is a personal space (starts with '~')")
+    void Should_UrlEncodeSpaceKey_When_DeploymentIsCloudAndSpaceKeyIsPersonal() {
+        when(confluenceConnectionConfig.baseUrl()).thenReturn(CLOUD_BASE_URL);
+        when(confluenceConnectionConfig.deploymentType()).thenReturn(ConfluenceDeploymentType.CLOUD);
+
+        String url = adapter.pageUrl(PERSONAL_SPACE_KEY, PAGE_ID);
+
+        String expectedEncodedSpaceKey = URLEncoder.encode(PERSONAL_SPACE_KEY, StandardCharsets.UTF_8);
+        assertThat(expectedEncodedSpaceKey)
+            .as("The personal space key must be URL-encoded (the '~' becomes '%7E')")
+            .isNotEqualTo(PERSONAL_SPACE_KEY);
+        assertThat(url).isEqualTo(CLOUD_BASE_URL + "/spaces/" + expectedEncodedSpaceKey + "/pages/" + PAGE_ID);
+    }
+
+    @Test
+    @DisplayName("Cloud deployment returns null when the space key is null (forces callers to provide a space key)")
+    void Should_ReturnNull_When_DeploymentIsCloudAndSpaceKeyIsNull() {
+        when(confluenceConnectionConfig.baseUrl()).thenReturn(CLOUD_BASE_URL);
+        when(confluenceConnectionConfig.deploymentType()).thenReturn(ConfluenceDeploymentType.CLOUD);
+
+        String url = adapter.pageUrl(null, PAGE_ID);
+
+        assertThat(url).isNull();
+    }
+
+    @Test
+    @DisplayName("Cloud deployment returns null when the space key is blank")
+    void Should_ReturnNull_When_DeploymentIsCloudAndSpaceKeyIsBlank() {
+        when(confluenceConnectionConfig.baseUrl()).thenReturn(CLOUD_BASE_URL);
+        when(confluenceConnectionConfig.deploymentType()).thenReturn(ConfluenceDeploymentType.CLOUD);
+
+        String url = adapter.pageUrl("   ", PAGE_ID);
+
+        assertThat(url).isNull();
+    }
+
+    @Test
+    @DisplayName("Cloud deployment trims a trailing slash from the base URL before appending the path")
+    void Should_TrimTrailingSlash_When_DeploymentIsCloudAndBaseUrlEndsWithSlash() {
+        when(confluenceConnectionConfig.baseUrl()).thenReturn(CLOUD_BASE_URL + "/");
+        when(confluenceConnectionConfig.deploymentType()).thenReturn(ConfluenceDeploymentType.CLOUD);
+
+        String url = adapter.pageUrl(STANDARD_SPACE_KEY, PAGE_ID);
+
+        assertThat(url).isEqualTo(CLOUD_BASE_URL + "/spaces/" + STANDARD_SPACE_KEY + "/pages/" + PAGE_ID);
+    }
+
+    @Test
+    @DisplayName("Data Center deployment keeps the legacy /pages/viewpage.action?pageId= format unchanged")
+    void Should_KeepLegacyDataCenterUrl_When_DeploymentIsDataCenterAndSpaceKeyIsProvided() {
+        when(confluenceConnectionConfig.baseUrl()).thenReturn(DC_BASE_URL);
+        when(confluenceConnectionConfig.deploymentType()).thenReturn(ConfluenceDeploymentType.DATA_CENTER);
+
+        String url = adapter.pageUrl(STANDARD_SPACE_KEY, PAGE_ID);
+
+        assertThat(url).isEqualTo(DC_BASE_URL + "/pages/viewpage.action?pageId=" + PAGE_ID);
+    }
+
+    @Test
+    @DisplayName("Data Center deployment ignores a null space key (legacy format does not need it)")
+    void Should_KeepLegacyDataCenterUrl_When_DeploymentIsDataCenterAndSpaceKeyIsNull() {
+        when(confluenceConnectionConfig.baseUrl()).thenReturn(DC_BASE_URL);
+        when(confluenceConnectionConfig.deploymentType()).thenReturn(ConfluenceDeploymentType.DATA_CENTER);
+
+        String url = adapter.pageUrl(null, PAGE_ID);
+
+        assertThat(url).isEqualTo(DC_BASE_URL + "/pages/viewpage.action?pageId=" + PAGE_ID);
+    }
+
+    @Test
+    @DisplayName("Data Center deployment ignores a blank space key (legacy format does not need it)")
+    void Should_KeepLegacyDataCenterUrl_When_DeploymentIsDataCenterAndSpaceKeyIsBlank() {
+        when(confluenceConnectionConfig.baseUrl()).thenReturn(DC_BASE_URL);
+        when(confluenceConnectionConfig.deploymentType()).thenReturn(ConfluenceDeploymentType.DATA_CENTER);
+
+        String url = adapter.pageUrl("   ", PAGE_ID);
+
+        assertThat(url).isEqualTo(DC_BASE_URL + "/pages/viewpage.action?pageId=" + PAGE_ID);
+    }
+
+    @Test
+    @DisplayName("Data Center deployment trims a trailing slash from the base URL")
+    void Should_TrimTrailingSlash_When_DeploymentIsDataCenterAndBaseUrlEndsWithSlash() {
+        when(confluenceConnectionConfig.baseUrl()).thenReturn(DC_BASE_URL + "/");
+        when(confluenceConnectionConfig.deploymentType()).thenReturn(ConfluenceDeploymentType.DATA_CENTER);
+
+        String url = adapter.pageUrl(STANDARD_SPACE_KEY, PAGE_ID);
+
+        assertThat(url).isEqualTo(DC_BASE_URL + "/pages/viewpage.action?pageId=" + PAGE_ID);
+    }
+
+    @Test
+    @DisplayName("Returns null when the page id is null regardless of deployment type")
+    void Should_ReturnNull_When_PageIdIsNull() {
+        lenient().when(confluenceConnectionConfig.baseUrl()).thenReturn(CLOUD_BASE_URL);
+        lenient().when(confluenceConnectionConfig.deploymentType()).thenReturn(ConfluenceDeploymentType.CLOUD);
+
+        String url = adapter.pageUrl(STANDARD_SPACE_KEY, null);
+
+        assertThat(url).isNull();
+    }
+
+    @Test
+    @DisplayName("Returns null when the page id is blank regardless of deployment type")
+    void Should_ReturnNull_When_PageIdIsBlank() {
+        lenient().when(confluenceConnectionConfig.baseUrl()).thenReturn(CLOUD_BASE_URL);
+        lenient().when(confluenceConnectionConfig.deploymentType()).thenReturn(ConfluenceDeploymentType.CLOUD);
+
+        String url = adapter.pageUrl(STANDARD_SPACE_KEY, "   ");
+
+        assertThat(url).isNull();
+    }
+
+    @Test
+    @DisplayName("Returns null when the configured base URL is null")
+    void Should_ReturnNull_When_BaseUrlIsNull() {
+        when(confluenceConnectionConfig.baseUrl()).thenReturn(null);
+
+        String url = adapter.pageUrl(STANDARD_SPACE_KEY, PAGE_ID);
+
+        assertThat(url).isNull();
+    }
+
+    @Test
+    @DisplayName("Returns null when the configured base URL is blank")
+    void Should_ReturnNull_When_BaseUrlIsBlank() {
+        when(confluenceConnectionConfig.baseUrl()).thenReturn("   ");
+
+        String url = adapter.pageUrl(STANDARD_SPACE_KEY, PAGE_ID);
+
+        assertThat(url).isNull();
+    }
+
+    // --- attachmentsUrl (Cloud: space-level list, Data Center: page-level list) ------------
+
+    @Test
+    @DisplayName("Cloud deployment builds /spaces/listattachmentsforspace.action?key={spaceKey} with a standard space key")
+    void Should_BuildCloudAttachmentsUrlWithSpaceKey_When_DeploymentIsCloudAndSpaceKeyIsStandard() {
+        when(confluenceConnectionConfig.baseUrl()).thenReturn("https://example.atlassian.net/wiki");
+        when(confluenceConnectionConfig.deploymentType()).thenReturn(ConfluenceDeploymentType.CLOUD);
+
+        String url = adapter.attachmentsUrl("TEST", PAGE_ID);
+
+        assertThat(url).isEqualTo("https://example.atlassian.net/wiki/spaces/listattachmentsforspace.action?key=TEST");
+    }
+
+    @Test
+    @DisplayName("Cloud attachments URL URL-encodes the space key when it is a personal space (starts with '~')")
+    void Should_UrlEncodeSpaceKey_When_AttachmentsUrlIsCloudAndSpaceKeyIsPersonal() {
+        when(confluenceConnectionConfig.baseUrl()).thenReturn(CLOUD_BASE_URL);
+        when(confluenceConnectionConfig.deploymentType()).thenReturn(ConfluenceDeploymentType.CLOUD);
+
+        String url = adapter.attachmentsUrl(PERSONAL_SPACE_KEY, PAGE_ID);
+
+        String expectedEncodedSpaceKey = URLEncoder.encode(PERSONAL_SPACE_KEY, StandardCharsets.UTF_8);
+        assertThat(expectedEncodedSpaceKey)
+            .as("The personal space key must be URL-encoded (the '~' becomes '%7E')")
+            .isNotEqualTo(PERSONAL_SPACE_KEY);
+        assertThat(url).isEqualTo(
+            CLOUD_BASE_URL + "/spaces/listattachmentsforspace.action?key=" + expectedEncodedSpaceKey);
+    }
+
+    @Test
+    @DisplayName("Cloud attachments URL returns null when the space key is blank (no space-level list can be built)")
+    void Should_ReturnNull_When_DeploymentIsCloudAndSpaceKeyIsBlank_OnAttachmentsUrl() {
+        when(confluenceConnectionConfig.baseUrl()).thenReturn(CLOUD_BASE_URL);
+        when(confluenceConnectionConfig.deploymentType()).thenReturn(ConfluenceDeploymentType.CLOUD);
+
+        String url = adapter.attachmentsUrl("   ", PAGE_ID);
+
+        assertThat(url).isNull();
+    }
+
+    @Test
+    @DisplayName("Cloud attachments URL ignores the page id (space-level listing only)")
+    void Should_IgnorePageId_When_DeploymentIsCloudOnAttachmentsUrl() {
+        when(confluenceConnectionConfig.baseUrl()).thenReturn(CLOUD_BASE_URL);
+        when(confluenceConnectionConfig.deploymentType()).thenReturn(ConfluenceDeploymentType.CLOUD);
+
+        String url = adapter.attachmentsUrl(STANDARD_SPACE_KEY, null);
+
+        assertThat(url).isEqualTo(CLOUD_BASE_URL + "/spaces/listattachmentsforspace.action?key=" + STANDARD_SPACE_KEY);
+    }
+
+    @Test
+    @DisplayName("Data Center attachments URL builds /pages/viewpageattachments.action?pageId={pageId}")
+    void Should_BuildDataCenterAttachmentsUrlWithPageId_When_DeploymentIsDataCenter() {
+        when(confluenceConnectionConfig.baseUrl()).thenReturn("https://example.com/wiki");
+        when(confluenceConnectionConfig.deploymentType()).thenReturn(ConfluenceDeploymentType.DATA_CENTER);
+
+        String url = adapter.attachmentsUrl(STANDARD_SPACE_KEY, "12345");
+
+        assertThat(url).isEqualTo("https://example.com/wiki/pages/viewpageattachments.action?pageId=12345");
+    }
+
+    @Test
+    @DisplayName("Data Center attachments URL returns null when the page id is blank")
+    void Should_ReturnNull_When_DeploymentIsDataCenterAndPageIdIsBlank_OnAttachmentsUrl() {
+        when(confluenceConnectionConfig.baseUrl()).thenReturn(DC_BASE_URL);
+        when(confluenceConnectionConfig.deploymentType()).thenReturn(ConfluenceDeploymentType.DATA_CENTER);
+
+        String url = adapter.attachmentsUrl(STANDARD_SPACE_KEY, "   ");
+
+        assertThat(url).isNull();
+    }
+
+    @Test
+    @DisplayName("Data Center attachments URL ignores the space key (page-level listing only)")
+    void Should_IgnoreSpaceKey_When_DeploymentIsDataCenterOnAttachmentsUrl() {
+        when(confluenceConnectionConfig.baseUrl()).thenReturn(DC_BASE_URL);
+        when(confluenceConnectionConfig.deploymentType()).thenReturn(ConfluenceDeploymentType.DATA_CENTER);
+
+        String url = adapter.attachmentsUrl(null, PAGE_ID);
+
+        assertThat(url).isEqualTo(DC_BASE_URL + "/pages/viewpageattachments.action?pageId=" + PAGE_ID);
+    }
+
+    @Test
+    @DisplayName("Attachments URL trims a trailing slash from the base URL on Cloud")
+    void Should_TrimTrailingSlash_When_AttachmentsUrlIsCloudAndBaseUrlEndsWithSlash() {
+        when(confluenceConnectionConfig.baseUrl()).thenReturn(CLOUD_BASE_URL + "/");
+        when(confluenceConnectionConfig.deploymentType()).thenReturn(ConfluenceDeploymentType.CLOUD);
+
+        String url = adapter.attachmentsUrl(STANDARD_SPACE_KEY, PAGE_ID);
+
+        assertThat(url).isEqualTo(CLOUD_BASE_URL + "/spaces/listattachmentsforspace.action?key=" + STANDARD_SPACE_KEY);
+    }
+
+    @Test
+    @DisplayName("Attachments URL trims a trailing slash from the base URL on Data Center")
+    void Should_TrimTrailingSlash_When_AttachmentsUrlIsDataCenterAndBaseUrlEndsWithSlash() {
+        when(confluenceConnectionConfig.baseUrl()).thenReturn(DC_BASE_URL + "/");
+        when(confluenceConnectionConfig.deploymentType()).thenReturn(ConfluenceDeploymentType.DATA_CENTER);
+
+        String url = adapter.attachmentsUrl(STANDARD_SPACE_KEY, PAGE_ID);
+
+        assertThat(url).isEqualTo(DC_BASE_URL + "/pages/viewpageattachments.action?pageId=" + PAGE_ID);
+    }
+
+    @Test
+    @DisplayName("Attachments URL returns null when the configured base URL is blank")
+    void Should_ReturnNull_When_AttachmentsUrlBaseUrlIsBlank() {
+        when(confluenceConnectionConfig.baseUrl()).thenReturn("   ");
+
+        String url = adapter.attachmentsUrl(STANDARD_SPACE_KEY, PAGE_ID);
+
+        assertThat(url).isNull();
+    }
+
+    @Test
+    @DisplayName("Attachments URL returns null when the configured base URL is null")
+    void Should_ReturnNull_When_AttachmentsUrlBaseUrlIsNull() {
+        when(confluenceConnectionConfig.baseUrl()).thenReturn(null);
+
+        String url = adapter.attachmentsUrl(STANDARD_SPACE_KEY, PAGE_ID);
+
+        assertThat(url).isNull();
+    }
+
+    @Test
+    @DisplayName("Cloud attachments URL returns null when both space key and page id are null")
+    void Should_ReturnNull_When_DeploymentIsCloudAndBothArgsAreNull_OnAttachmentsUrl() {
+        when(confluenceConnectionConfig.baseUrl()).thenReturn(CLOUD_BASE_URL);
+        when(confluenceConnectionConfig.deploymentType()).thenReturn(ConfluenceDeploymentType.CLOUD);
+
+        String url = adapter.attachmentsUrl(null, null);
+
+        assertThat(url).isNull();
+    }
+
+    @Test
+    @DisplayName("Data Center attachments URL returns null when both space key and page id are null")
+    void Should_ReturnNull_When_DeploymentIsDataCenterAndBothArgsAreNull_OnAttachmentsUrl() {
+        when(confluenceConnectionConfig.baseUrl()).thenReturn(DC_BASE_URL);
+        when(confluenceConnectionConfig.deploymentType()).thenReturn(ConfluenceDeploymentType.DATA_CENTER);
+
+        String url = adapter.attachmentsUrl(null, null);
+
+        assertThat(url).isNull();
+    }
+
+    // --- Form-encoding guarantees for exotic space keys (pageUrl + attachmentsUrl) ---------
+    // URLEncoder.encode uses application/x-www-form-urlencoded semantics:
+    //   ' ' -> '+'    '/' -> '%2F'    '%' -> '%25'
+    // These tests lock the behavior so any future refactor of urlEncode stays explicit.
+
+    @ParameterizedTest(name = "pageUrl Cloud encodes ''{0}'' as ''{1}''")
+    @CsvSource({
+        "'space key', 'space+key'",
+        "'a/b',       'a%2Fb'",
+        "'50%',       '50%25'"
+    })
+    @DisplayName("pageUrl form-encodes exotic characters in the space key on Cloud")
+    void Should_FormEncodeSpaceKey_When_DeploymentIsCloudOnPageUrl(String rawSpaceKey, String expectedEncoded) {
+        when(confluenceConnectionConfig.baseUrl()).thenReturn(CLOUD_BASE_URL);
+        when(confluenceConnectionConfig.deploymentType()).thenReturn(ConfluenceDeploymentType.CLOUD);
+
+        String url = adapter.pageUrl(rawSpaceKey, PAGE_ID);
+
+        assertThat(url).isEqualTo(CLOUD_BASE_URL + "/spaces/" + expectedEncoded + "/pages/" + PAGE_ID);
+    }
+
+    @ParameterizedTest(name = "attachmentsUrl Cloud encodes ''{0}'' as ''{1}''")
+    @CsvSource({
+        "'space key', 'space+key'",
+        "'a/b',       'a%2Fb'",
+        "'50%',       '50%25'"
+    })
+    @DisplayName("attachmentsUrl form-encodes exotic characters in the space key on Cloud")
+    void Should_FormEncodeSpaceKey_When_DeploymentIsCloudOnAttachmentsUrl(String rawSpaceKey, String expectedEncoded) {
+        when(confluenceConnectionConfig.baseUrl()).thenReturn(CLOUD_BASE_URL);
+        when(confluenceConnectionConfig.deploymentType()).thenReturn(ConfluenceDeploymentType.CLOUD);
+
+        String url = adapter.attachmentsUrl(rawSpaceKey, PAGE_ID);
+
+        assertThat(url).isEqualTo(CLOUD_BASE_URL + "/spaces/listattachmentsforspace.action?key=" + expectedEncoded);
+    }
+}

--- a/pii-reporting-api/src/test/java/pro/softcom/aisentinel/integration/ExcelExportFullScanIntegrationTest.java
+++ b/pii-reporting-api/src/test/java/pro/softcom/aisentinel/integration/ExcelExportFullScanIntegrationTest.java
@@ -129,10 +129,10 @@ class ExcelExportFullScanIntegrationTest {
         // PHASE 1: ARRANGE - Mock Confluence Content
         // ============================================
         
-        var space = createTestSpace("TEST", "Test Space for Excel Export");
-        var page1 = createPageWithEmailsAndPhones("page-1", "TEST");
-        var page2 = createPageWithAVS("page-2", "TEST");
-        var page3 = createPageWithSecurityData("page-3", "TEST");
+        var space = createTestSpace();
+        var page1 = createPageWithEmailsAndPhones();
+        var page2 = createPageWithAVS();
+        var page3 = createPageWithSecurityData();
         
         when(confluenceClient.getAllSpaces())
             .thenReturn(CompletableFuture.completedFuture(List.of(space)));
@@ -144,10 +144,16 @@ class ExcelExportFullScanIntegrationTest {
         // CRITICAL FIX: Mock pageUrl() for each page - used by ScanEventFactory
         when(confluenceUrlProvider.baseUrl())
             .thenReturn("http://test.confluence.local");
-        when(confluenceUrlProvider.pageUrl(anyString()))
+        when(confluenceUrlProvider.pageUrl(anyString(), anyString()))
             .thenAnswer(invocation -> {
-                String pageId = invocation.getArgument(0);
-                return "http://test.confluence.local/pages/" + pageId;
+                String spaceKey = invocation.getArgument(0);
+                String pageId = invocation.getArgument(1);
+                return "http://test.confluence.local/spaces/" + spaceKey + "/pages/" + pageId;
+            });
+        when(confluenceUrlProvider.attachmentsUrl(anyString(), anyString()))
+            .thenAnswer(invocation -> {
+                String spaceKey = invocation.getArgument(0);
+                return "http://test.confluence.local/spaces/listattachmentsforspace.action?key=" + spaceKey;
             });
         
         // ============================================
@@ -306,20 +312,25 @@ class ExcelExportFullScanIntegrationTest {
         // Collecter tous les types PII détectés
         List<String> detectedTypes = new ArrayList<>();
         List<String> pageTitles = new ArrayList<>();
-        
+        List<String> pageUrls = new ArrayList<>();
+
         for (int i = 1; i <= totalDetections; i++) {
             Row row = detectionsSheet.getRow(i);
             if (row != null) {
                 String pageTitle = getCellValue(row, 1);
+                String pageUrl = getCellValue(row, 2);
                 String piiType = getCellValue(row, 6);
-                
+
                 if (pageTitle != null) {
                     pageTitles.add(pageTitle);
+                }
+                if (pageUrl != null) {
+                    pageUrls.add(pageUrl);
                 }
                 if (piiType != null) {
                     detectedTypes.add(piiType);
                 }
-                
+
                 // Vérifier que le confidence score est valide
                 Cell scoreCell = row.getCell(5);
                 if (scoreCell != null && scoreCell.getCellType() == CellType.NUMERIC) {
@@ -330,6 +341,19 @@ class ExcelExportFullScanIntegrationTest {
                 }
             }
         }
+
+        // Non-regression guard for the Cloud page URL format:
+        // the fix 1 makes sure pageUrl contains the /spaces/{spaceKey}/pages/{pageId} segment,
+        // not the old buggy /pages/{pageId}. Assertion reuses the stubbed provider shape.
+        softly.assertThat(pageUrls)
+            .as("Every detection row must expose a non-blank Page Url built from the Cloud format")
+            .isNotEmpty()
+            .allSatisfy(url -> softly.assertThat(url)
+                .as("Page Url should match the Cloud /spaces/{spaceKey}/pages/{pageId} shape")
+                .startsWith("http://test.confluence.local/spaces/TEST/pages/"));
+        softly.assertThat(pageUrls)
+            .as("At least one detection row must target the first test page")
+            .contains("http://test.confluence.local/spaces/TEST/pages/page-1");
         
         // Vérifier qu'on a des détections de différents types
         // Note: L'Excel utilise les labels français avec majuscules
@@ -382,12 +406,12 @@ class ExcelExportFullScanIntegrationTest {
         };
     }
 
-    private ConfluenceSpace createTestSpace(String key, String name) {
+    private ConfluenceSpace createTestSpace() {
         return new ConfluenceSpace(
-            "id-" + key,
-            key,
-            name,
-            "http://test.confluence.local/spaces/" + key,
+            "id-" + "TEST",
+                "TEST",
+                "Test Space for Excel Export",
+            "http://test.confluence.local/spaces/" + "TEST",
             "Test space for integration testing",
             ConfluenceSpace.SpaceType.GLOBAL,
             ConfluenceSpace.SpaceStatus.CURRENT,
@@ -396,11 +420,11 @@ class ExcelExportFullScanIntegrationTest {
         );
     }
 
-    private ConfluencePage createPageWithEmailsAndPhones(String id, String spaceKey) {
+    private ConfluencePage createPageWithEmailsAndPhones() {
         return ConfluencePage.builder()
-            .id(id)
+            .id("page-1")
             .title("Contact Information")
-            .spaceKey(spaceKey)
+            .spaceKey("TEST")
             .content(new ConfluencePage.HtmlContent("""
                 <html>
                 <body>
@@ -426,11 +450,11 @@ class ExcelExportFullScanIntegrationTest {
             .build();
     }
 
-    private ConfluencePage createPageWithAVS(String id, String spaceKey) {
+    private ConfluencePage createPageWithAVS() {
         return ConfluencePage.builder()
-            .id(id)
+            .id("page-2")
             .title("Employee Records")
-            .spaceKey(spaceKey)
+            .spaceKey("TEST")
             .content(new ConfluencePage.HtmlContent("""
                 <html>
                 <body>
@@ -455,11 +479,11 @@ class ExcelExportFullScanIntegrationTest {
             .build();
     }
 
-    private ConfluencePage createPageWithSecurityData(String id, String spaceKey) {
+    private ConfluencePage createPageWithSecurityData() {
         return ConfluencePage.builder()
-            .id(id)
+            .id("page-3")
             .title("System Configuration")
-            .spaceKey(spaceKey)
+            .spaceKey("TEST")
             .content(new ConfluencePage.HtmlContent("""
                 <html>
                 <body>

--- a/pii-reporting-ui/package.json
+++ b/pii-reporting-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sentinel-ui-angular",
-  "version": "1.1.0-SNAPSHOT",
+  "version": "1.1.1-SNAPSHOT",
   "license": "Apache-2.0",
   "engines": {
     "node": ">=20.19 <21 || >=22.12"


### PR DESCRIPTION
 ## Summary
  - Fix the "Open in Confluence" button that generated invalid URLs on Confluence Cloud
  - Page deep-links now include the required `/spaces/{spaceKey}/` segment
  - Attachment events get dedicated URLs (Cloud: space-level attachments list, Data Center: page-level attachments list)

  ## Context
  Before this fix, Cloud instances produced `{base}/wiki/pages/{pageId}`, which is not a resolvable URL. The correct Cloud format is
  `{base}/wiki/spaces/{spaceKey}/pages/{pageId}`. Data Center's existing `/pages/viewpage.action?pageId={pageId}` is confirmed by Atlassian documentation
  as the canonical deep-link when only the pageId is available, so the DC branch stays untouched.

  ## Changes
  - `ConfluenceUrlProvider` port: `pageUrl` gains a `spaceKey` parameter; new `attachmentsUrl(spaceKey, pageId)` method
  - `ConfluenceUrlProviderAdapter`: Cloud branch rebuilds the URL with URL-encoded `spaceKey` (handles personal spaces starting with `~`); Data Center
  branch preserved textually
  - `ScanEventFactory`: `spaceKey` propagated to all 6 event builders; `ATTACHMENT_ITEM` events now expose the attachments-list URL while the raw
  `attachmentUrl` field (direct file download) stays intact
  - Tests:
    - New `ConfluenceUrlProviderAdapterTest` — 33 tests covering Cloud/DC branches, form-encoding edge cases (`space`, `/`, `%`), null handling
    - New `ScanEventFactoryTest` — locks which port method is invoked per event type
    - `ExcelExportFullScanIntegrationTest` — asserts the new Cloud format on every detection row (anti-regression guard)
    - Deduplicated anonymous `ConfluenceUrlProvider` implementations in stream use-case tests via a Mockito helper


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added UI settings docs for detector toggles, selectable PII types, and global/per-type confidence thresholds.
  * Documented zero-shot custom-label workflow (with reliability note), enhanced Docker full-reinstall cleanup steps, and expanded FAQ.

* **Bug Fixes**
  * Reporting links updated to use space-scoped page and attachments URLs so report links resolve correctly in recent Confluence deployments.

* **Chores**
  * Bumped component package versions (detector, reporting API, reporting UI).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->