### PR TITLE
Revert "chore: bump service versions to v1.1.1 in Docker and source f…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -557,7 +557,7 @@ services:
   # PII DETECTOR SERVICE (Python/gRPC) - PRE-BUILT IMAGE
   # ============================================================================
   pii-detector:
-    image: ghcr.io/softcom-technologies-organization/ai-sentinel-pii-detector:v1.1.1-rc.1
+    image: ghcr.io/softcom-technologies-organization/ai-sentinel-pii-detector:v1.1.0-rc.1
     container_name: pii-detector-service
     restart: unless-stopped
     
@@ -612,7 +612,7 @@ services:
   # PII REPORTING API (Spring Boot) - PRE-BUILT IMAGE
   # ============================================================================
   pii-reporting-api:
-    image: ghcr.io/softcom-technologies-organization/ai-sentinel-reporting-api:v1.1.1-rc.1
+    image: ghcr.io/softcom-technologies-organization/ai-sentinel-reporting-api:v1.1.0-rc.1
     container_name: pii-reporting-api
     restart: unless-stopped
     ports:
@@ -661,7 +661,7 @@ services:
   # PII REPORTING UI (Angular + Nginx) - PRE-BUILT IMAGE
   # ============================================================================
   pii-reporting-ui:
-    image: ghcr.io/softcom-technologies-organization/ai-sentinel-reporting-ui:v1.1.1-rc.1
+    image: ghcr.io/softcom-technologies-organization/ai-sentinel-reporting-ui:v1.1.0-rc.1
     container_name: pii-reporting-ui
     restart: unless-stopped
     ports:

--- a/pii-detector-service/pyproject.toml
+++ b/pii-detector-service/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pii-detector"
-version = "1.1.1.dev0"
+version = "1.1.0.dev0"
 description = "PII Detection gRPC Microservice using Piiranha model with advanced memory management"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pii-reporting-api/pom.xml
+++ b/pii-reporting-api/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>pro.softcom</groupId>
     <artifactId>ai-sentinel</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <name>ai-sentinel</name>
     <description>ai-sentinel - Application to scan Confluence spaces and reporting PIIs</description>
 

--- a/pii-reporting-ui/package.json
+++ b/pii-reporting-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sentinel-ui-angular",
-  "version": "1.1.1-SNAPSHOT",
+  "version": "1.1.0-SNAPSHOT",
   "license": "Apache-2.0",
   "engines": {
     "node": ">=20.19 <21 || >=22.12"


### PR DESCRIPTION
This reverts commit 171e717ca53d26b06f63fc2ced13a1debb4cc769. It's breaking the docker compose since the image tag is generated from the branch name, not from the version tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service versions to 1.1.0 across pii-detector, pii-reporting-api, and pii-reporting-ui.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->