### PR TITLE
fix(pii-detector): align GLiNER chunker on whitespace tokens to stop silent truncation

### DIFF
--- a/pii-detector-service/pii_detector/infrastructure/detector/gliner_detector.py
+++ b/pii-detector-service/pii_detector/infrastructure/detector/gliner_detector.py
@@ -17,7 +17,7 @@ from pii_detector.domain.exception.exceptions import ModelNotLoadedError, PIIDet
 from pii_detector.infrastructure.model_management.gliner_model_manager import \
     GLiNERModelManager
 from pii_detector.infrastructure.text_processing.semantic_chunker import \
-    create_chunker
+    WhitespaceWordWindowChunker
 
 
 class GLiNERDetector:
@@ -70,9 +70,8 @@ class GLiNERDetector:
             self.model = self.model_manager.load_model()
             self.logger.info("GLiNER model loaded successfully")
             
-            # Initialize text chunker with GLiNER's tokenizer
-            # GLiNER (nvidia/gliner-pii) has internal 378-token limit
-            # Character-based chunking with overlap handles long texts
+            # Initialize whitespace-token chunker aligned with GLiNER's
+            # 384 max_len (counted on whitespace tokens, not subwords).
             self._initialize_text_chunker()
                 
         except Exception as e:
@@ -120,16 +119,15 @@ class GLiNERDetector:
         """
         Initialize text chunker for GLiNER processing.
 
-        Uses character-based chunking with overlap to handle GLiNER's 378 token limit.
+        Uses ``WhitespaceWordWindowChunker`` which counts tokens with the same
+        regex as GLiNER's internal ``WhitespaceTokenSplitter`` — guarantees
+        no chunk exceeds GLiNER's 384-token max_len and prevents the silent
+        truncation observed with subword/char-based chunking.
         """
         try:
-            tokenizer = self._get_tokenizer_from_model()
-
-            self.semantic_chunker = create_chunker(
-                tokenizer=tokenizer,
-                chunk_size=378,  # GLiNER's internal token limit (nvidia/gliner-pii)
-                overlap=100,     # ~300 char overlap to catch entities at boundaries
-                use_semantic=False,  # Character-based chunking supports overlap
+            self.semantic_chunker = WhitespaceWordWindowChunker(
+                chunk_size=380,  # GLiNER max_len is 384 whitespace tokens; 4 of margin
+                overlap=80,      # ~21% overlap for cross-boundary entity detection
                 logger=self.logger
             )
 

--- a/pii-detector-service/pii_detector/infrastructure/text_processing/semantic_chunker.py
+++ b/pii-detector-service/pii_detector/infrastructure/text_processing/semantic_chunker.py
@@ -7,9 +7,10 @@ Critical for models like GLiNER that have internal sentence-level token limits.
 """
 
 import logging
+import re
 import time
 from dataclasses import dataclass
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Tuple
 
 try:
     import semchunk
@@ -247,6 +248,100 @@ class FallbackChunker:
             "chars_per_token": self.chars_per_token,
             "library": "fallback",
             "available": True
+        }
+
+
+class WhitespaceWordWindowChunker:
+    """
+    Word-window chunker aligned with GLiNER's internal ``WhitespaceTokenSplitter``.
+
+    GLiNER applies its ``max_len`` limit (e.g. 384) to *whitespace tokens* — words
+    plus isolated punctuation — not to subword tokens. Char-based or subword-based
+    chunking upstream may leave chunks that exceed the word limit on dense input
+    (URLs, identifiers, code), causing GLiNER to silently truncate beyond
+    ``max_len`` and drop entities at the tail.
+
+    This chunker reproduces the exact regex GLiNER uses
+    (``\\w+(?:[-_]\\w+)*|\\S``) to count whitespace tokens, so configuring
+    ``chunk_size`` strictly below ``max_len`` guarantees no internal truncation.
+
+    Char positions are taken from the regex match offsets, keeping
+    char-based offset alignment with the rest of the pipeline.
+    """
+
+    # Aligned with gliner.data_processing.tokenizer.WhitespaceTokenSplitter
+    _GLINER_WHITESPACE_PATTERN = re.compile(r"\w+(?:[-_]\w+)*|\S")
+
+    def __init__(
+        self,
+        chunk_size: int,
+        overlap: int,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        if chunk_size <= overlap:
+            raise ValueError(
+                f"chunk_size ({chunk_size}) must be greater than overlap ({overlap})"
+            )
+        if chunk_size <= 0:
+            raise ValueError(f"chunk_size ({chunk_size}) must be > 0")
+
+        self._chunk_size = chunk_size
+        self._overlap = overlap
+        self._stride = chunk_size - overlap
+        self._logger = logger or logging.getLogger(__name__)
+
+        self._logger.info(
+            "WhitespaceWordWindowChunker initialized: "
+            f"chunk_size={chunk_size} (whitespace tokens), overlap={overlap}, "
+            "aligned with GLiNER WhitespaceTokenSplitter"
+        )
+
+    def chunk_text(self, text: str) -> List[ChunkResult]:
+        """Split ``text`` into windows bounded by GLiNER-aligned token counts."""
+        if not text:
+            return []
+
+        token_spans: List[Tuple[int, int]] = [
+            (m.start(), m.end())
+            for m in self._GLINER_WHITESPACE_PATTERN.finditer(text)
+        ]
+        if not token_spans:
+            return []
+
+        total = len(token_spans)
+        if total <= self._chunk_size:
+            start_char = token_spans[0][0]
+            end_char = token_spans[-1][1]
+            return [ChunkResult(
+                text=text[start_char:end_char],
+                start=start_char,
+                end=end_char,
+                token_count=total,
+            )]
+
+        chunks: List[ChunkResult] = []
+        i = 0
+        while i < total:
+            j = min(i + self._chunk_size, total)
+            start_char = token_spans[i][0]
+            end_char = token_spans[j - 1][1]
+            chunks.append(ChunkResult(
+                text=text[start_char:end_char],
+                start=start_char,
+                end=end_char,
+                token_count=j - i,
+            ))
+            if j >= total:
+                break
+            i += self._stride
+        return chunks
+
+    def get_chunk_info(self) -> dict:
+        return {
+            "chunk_size": self._chunk_size,
+            "overlap": self._overlap,
+            "library": "gliner-aligned-whitespace",
+            "available": True,
         }
 
 

--- a/pii-detector-service/tests/unit/infrastructure/detector/test_gliner_detector_load_model.py
+++ b/pii-detector-service/tests/unit/infrastructure/detector/test_gliner_detector_load_model.py
@@ -52,7 +52,7 @@ class TestGLiNERDetectorLoadModel:
         mock_chunker = Mock()
         mock_chunker.get_chunk_info = Mock(return_value={"library": "semchunk"})
         
-        with patch('pii_detector.infrastructure.detector.gliner_detector.create_chunker', 
+        with patch('pii_detector.infrastructure.detector.gliner_detector.WhitespaceWordWindowChunker', 
                    return_value=mock_chunker) as mock_create:
             # Act
             detector.load_model()
@@ -61,13 +61,13 @@ class TestGLiNERDetectorLoadModel:
             assert detector.model == mock_model
             assert detector.semantic_chunker == mock_chunker
             
-            # Verify create_chunker was called with correct params
+            # Verify WhitespaceWordWindowChunker was instantiated with correct params.
+            # chunk_size must stay strictly below GLiNER's max_len (384 whitespace
+            # tokens) so the model never silently truncates a chunk.
             mock_create.assert_called_once()
             call_kwargs = mock_create.call_args.kwargs
-            assert call_kwargs['tokenizer'] == mock_tokenizer
-            assert call_kwargs['chunk_size'] == 378  # GLiNER's internal token limit
-            assert call_kwargs['overlap'] == 100
-            assert call_kwargs['use_semantic'] is False  # Character-based chunking
+            assert call_kwargs['chunk_size'] == 380
+            assert call_kwargs['overlap'] == 80
 
     def test_should_loadmodel_when_tokenizer_not_in_data_processor_uses_fallback(self, detector):
         """
@@ -95,7 +95,7 @@ class TestGLiNERDetectorLoadModel:
         mock_chunker = Mock()
         mock_chunker.get_chunk_info = Mock(return_value={"library": "semchunk"})
         
-        with patch('pii_detector.infrastructure.detector.gliner_detector.create_chunker',
+        with patch('pii_detector.infrastructure.detector.gliner_detector.WhitespaceWordWindowChunker',
                    return_value=mock_chunker):
             with patch('transformers.AutoTokenizer.from_pretrained',
                        return_value=mock_auto_tokenizer) as mock_from_pretrained:
@@ -106,8 +106,9 @@ class TestGLiNERDetectorLoadModel:
                 assert detector.model == mock_model
                 assert detector.semantic_chunker == mock_chunker
                 
-                # Verify AutoTokenizer.from_pretrained was called with model name
-                mock_from_pretrained.assert_called_once_with("bert-base-cased")
+                # The whitespace-aligned chunker no longer depends on a HF
+                # tokenizer, so the AutoTokenizer fallback path stays dormant.
+                mock_from_pretrained.assert_not_called()
 
     def test_should_load_model_when_chunker_uses_fallback_library(self, detector):
         """
@@ -127,7 +128,7 @@ class TestGLiNERDetectorLoadModel:
         mock_chunker = Mock()
         mock_chunker.get_chunk_info = Mock(return_value={"library": "fallback"})
 
-        with patch('pii_detector.infrastructure.detector.gliner_detector.create_chunker',
+        with patch('pii_detector.infrastructure.detector.gliner_detector.WhitespaceWordWindowChunker',
                    return_value=mock_chunker):
             # Act - should complete without error
             detector.load_model()
@@ -149,7 +150,7 @@ class TestGLiNERDetectorLoadModel:
         detector.model_manager.load_model = Mock(return_value=mock_model)
 
         # Mock create_chunker to raise an exception
-        with patch('pii_detector.infrastructure.detector.gliner_detector.create_chunker',
+        with patch('pii_detector.infrastructure.detector.gliner_detector.WhitespaceWordWindowChunker',
                    side_effect=Exception("Chunker initialization failed")):
             # Act & Assert
             with pytest.raises(RuntimeError,
@@ -190,15 +191,14 @@ class TestGLiNERDetectorLoadModel:
         mock_chunker = Mock()
         mock_chunker.get_chunk_info = Mock(return_value={"library": "semchunk"})
 
-        with patch('pii_detector.infrastructure.detector.gliner_detector.create_chunker',
+        with patch('pii_detector.infrastructure.detector.gliner_detector.WhitespaceWordWindowChunker',
                    return_value=mock_chunker) as mock_create:
             # Act
             detector.load_model()
 
-            # Assert
+            # Assert: chunker is instantiated independently of any tokenizer.
             assert detector.model == mock_model
-            call_kwargs = mock_create.call_args.kwargs
-            assert call_kwargs['tokenizer'] == mock_tokenizer
+            mock_create.assert_called_once()
 
     def test_should_fallback_to_auto_tokenizer_when_data_processor_is_none(self, detector):
         """
@@ -219,17 +219,18 @@ class TestGLiNERDetectorLoadModel:
         mock_chunker = Mock()
         mock_chunker.get_chunk_info = Mock(return_value={"library": "semchunk"})
 
-        with patch('pii_detector.infrastructure.detector.gliner_detector.create_chunker',
+        with patch('pii_detector.infrastructure.detector.gliner_detector.WhitespaceWordWindowChunker',
                    return_value=mock_chunker):
             with patch('transformers.AutoTokenizer.from_pretrained',
                        return_value=mock_auto_tokenizer) as mock_from_pretrained:
                 # Act
                 detector.load_model()
 
-                # Assert - should complete successfully using fallback
+                # Assert - should complete successfully without touching the
+                # HF tokenizer (chunker is now whitespace-aligned).
                 assert detector.model == mock_model
                 assert detector.semantic_chunker == mock_chunker
-                mock_from_pretrained.assert_called_once_with("bert-base-cased")
+                mock_from_pretrained.assert_not_called()
 
     def test_should_log_success_when_model_loads_correctly(self, detector, caplog):
         """
@@ -246,7 +247,7 @@ class TestGLiNERDetectorLoadModel:
         mock_chunker = Mock()
         mock_chunker.get_chunk_info = Mock(return_value={"library": "semchunk"})
 
-        with patch('pii_detector.infrastructure.detector.gliner_detector.create_chunker',
+        with patch('pii_detector.infrastructure.detector.gliner_detector.WhitespaceWordWindowChunker',
                    return_value=mock_chunker):
             # Act
             with caplog.at_level("INFO"):
@@ -268,7 +269,7 @@ class TestGLiNERDetectorLoadModel:
 
         detector.model_manager.load_model = Mock(return_value=mock_model)
 
-        with patch('pii_detector.infrastructure.detector.gliner_detector.create_chunker',
+        with patch('pii_detector.infrastructure.detector.gliner_detector.WhitespaceWordWindowChunker',
                    side_effect=Exception("Chunker failed")):
             # Act & Assert
             with caplog.at_level("ERROR"):

--- a/pii-detector-service/tests/unit/test_gliner_detector.py
+++ b/pii-detector-service/tests/unit/test_gliner_detector.py
@@ -71,7 +71,7 @@ class TestModelManagement:
         
         mock_manager.download_model.assert_called_once()
     
-    @patch('pii_detector.infrastructure.detector.gliner_detector.create_chunker')
+    @patch('pii_detector.infrastructure.detector.gliner_detector.WhitespaceWordWindowChunker')
     @patch('pii_detector.infrastructure.detector.gliner_detector.GLiNERModelManager')
     @patch('transformers.AutoTokenizer')
     def test_should_load_model_successfully(self, mock_tokenizer_class, mock_manager_class, mock_create_chunker):
@@ -100,37 +100,41 @@ class TestModelManagement:
         assert detector.model is mock_model
         assert detector.semantic_chunker is mock_chunker
     
-    @patch('pii_detector.infrastructure.detector.gliner_detector.create_chunker')
+    @patch('pii_detector.infrastructure.detector.gliner_detector.WhitespaceWordWindowChunker')
     @patch('pii_detector.infrastructure.detector.gliner_detector.GLiNERModelManager')
     @patch('transformers.AutoTokenizer')
-    def test_should_use_fallback_tokenizer(self, mock_tokenizer_class, mock_manager_class, mock_create_chunker):
-        """Test loading with fallback tokenizer."""
+    def test_should_load_without_external_tokenizer(self, mock_tokenizer_class, mock_manager_class, mock_create_chunker):
+        """Loading must not require any external tokenizer download.
+
+        The chunker is now ``WhitespaceWordWindowChunker``, aligned with GLiNER's
+        whitespace splitter. It does not need a HuggingFace tokenizer, so the
+        ``AutoTokenizer.from_pretrained`` fallback path must remain dormant.
+        """
         mock_manager = Mock()
         mock_model = Mock()
         mock_data_processor = Mock()
         mock_config = Mock()
-        mock_tokenizer = Mock()
-        
+
         mock_config.tokenizer = None
         mock_data_processor.transformer_tokenizer = None
         mock_data_processor.config = mock_config
         mock_model.data_processor = mock_data_processor
         mock_model.config = Mock(model_name='bert-base-cased')
-        
+
         mock_manager.load_model.return_value = mock_model
         mock_manager_class.return_value = mock_manager
-        mock_tokenizer_class.from_pretrained.return_value = mock_tokenizer
-        
+
         mock_chunker = Mock()
-        mock_chunker.get_chunk_info.return_value = {"library": "semchunk"}
+        mock_chunker.get_chunk_info.return_value = {"library": "gliner-aligned-whitespace"}
         mock_create_chunker.return_value = mock_chunker
-        
+
         detector = GLiNERDetector()
         detector.load_model()
-        
-        mock_tokenizer_class.from_pretrained.assert_called_once()
+
+        mock_tokenizer_class.from_pretrained.assert_not_called()
+        assert detector.semantic_chunker is mock_chunker
     
-    @patch('pii_detector.infrastructure.detector.gliner_detector.create_chunker')
+    @patch('pii_detector.infrastructure.detector.gliner_detector.WhitespaceWordWindowChunker')
     @patch('pii_detector.infrastructure.detector.gliner_detector.GLiNERModelManager')
     @patch('transformers.AutoTokenizer')
     def test_should_accept_fallback_chunker(self, mock_tokenizer_class, mock_manager_class, mock_create_chunker):


### PR DESCRIPTION
GLiNER applies its `max_len=384` limit on whitespace tokens (its internal
WhitespaceTokenSplitter regex), not on subword/char tokens. The previous
char-based chunker (chunk_size=378, overlap=100, ~3 chars/token) produced
chunks that silently exceeded GLiNER's word limit on dense input (URLs,
identifiers, code), causing entities at the tail of long pages/attachments
to be dropped.

Replace `create_chunker` with `WhitespaceWordWindowChunker`, which counts
tokens with the exact same regex as GLiNER (`\w+(?:[-_]\w+)*|\S`) and
uses chunk_size=380, overlap=80 — strictly below the 384 cap, so GLiNER
never truncates internally. Char offsets are preserved so the rest of
the pipeline keeps working unchanged.

Reimplemented from commits 8bd3c99 and 2f92f4e
(branch feature/gemma-4-debug-missing-findings-from-gliner), keeping only
the chunker fix and dropping the unrelated ONNX/batch-inference/bench
observability changes.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized text chunking for PII detection to eliminate truncation issues and improve detection accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->